### PR TITLE
Make inital state `sending`

### DIFF
--- a/Sources/Oak/Transducer.SwiftUI.swift
+++ b/Sources/Oak/Transducer.SwiftUI.swift
@@ -116,7 +116,7 @@ public struct TransducerView<T: Transducer, Content: View>: View where T.State: 
     /// by the transducer.
     public init<Output: Sendable, Out: Subject<Output>>(
         of type: T.Type,
-        initialState: T.State,
+        initialState: sending T.State,
         proxy: T.Proxy? = nil,
         out: Out,
         initialOutput: Output? = nil,
@@ -159,7 +159,7 @@ public struct TransducerView<T: Transducer, Content: View>: View where T.State: 
 
     public init(
         of type: T.Type,
-        initialState: T.State,
+        initialState: sending T.State,
         proxy: T.Proxy? = nil,
         @ViewBuilder content: @escaping (_ state: T.State, _ send: @escaping (T.Event) -> Void) -> Content
     ) where T.TransducerOutput == Void, T.Env == Never {
@@ -196,7 +196,7 @@ public struct TransducerView<T: Transducer, Content: View>: View where T.State: 
 
     public init<Output: Sendable, Out: Subject<Output>>(
         of type: T.Type,
-        initialState: T.State,
+        initialState: sending T.State,
         proxy: T.Proxy? = nil,
         env: T.Env,
         out: Out,
@@ -243,7 +243,7 @@ public struct TransducerView<T: Transducer, Content: View>: View where T.State: 
 
     public init(
         of type: T.Type,
-        initialState: T.State,
+        initialState: sending T.State,
         proxy: T.Proxy? = nil,
         env: T.Env,
         @ViewBuilder content: @escaping (_ state: T.State, _ send: @escaping (T.Event) -> Void) -> Content

--- a/Sources/Oak/Transducer.swift
+++ b/Sources/Oak/Transducer.swift
@@ -343,7 +343,7 @@ extension Transducer where Env == Never {
     @discardableResult
     public static func run<Output>(
         isolated: isolated any Actor = #isolation,
-        initialState: State,
+        initialState: sending State,
         proxy: Proxy,
         out: some Subject<Output>,
         initialOutput: Output? = nil
@@ -374,7 +374,7 @@ extension Transducer where Env == Never {
     @discardableResult
     public static func run<Output>(
         isolated: isolated any Actor = #isolation,
-        initialState: State,
+        initialState: sending State,
         proxy: Proxy
     ) async throws -> Output where Output == TransducerOutput {
         try await run(
@@ -656,7 +656,7 @@ extension Transducer where Env: Sendable {
     @discardableResult
     public static func run<Output: Sendable>(
         isolated: isolated any Actor = #isolation,
-        initialState: State,
+        initialState: sending State,
         proxy: Proxy,
         env: Env,
         out: some Subject<Output>,
@@ -697,7 +697,7 @@ extension Transducer where Env: Sendable {
     @discardableResult
     public static func run<Output: Sendable>(
         isolated: isolated any Actor = #isolation,
-        initialState: State,
+        initialState: sending State,
         proxy: Proxy,
         env: Env
     ) async throws -> Output where Self.TransducerOutput == (Oak.Effect<Event, Env>?, Output) {
@@ -997,12 +997,12 @@ internal struct LocalStorage<Value>: Storage {
     final class Reference {
         var value: Value
 
-        init(value: Value) {
+        init(value: sending Value) {
             self.value = value
         }
     }
     
-    init(value: Value) {
+    init(value: sending Value) {
         storage = Reference(value: value)
     }
     

--- a/Tests/OakTests/TransducerTest.swift
+++ b/Tests/OakTests/TransducerTest.swift
@@ -105,7 +105,7 @@ extension TransducerTests {
                 static func update(_ state: inout State, event: Event) -> Void { }
             }
             let proxy = T.Proxy()
-            let result: Void = try await T.run(initialState: .start, proxy: proxy)
+            let result: Void = try await T.run(initialState: .start, proxy: proxy, out: NoCallbacks(), initialOutput: Void())
             #expect(result == ())
         }
      
@@ -612,7 +612,7 @@ extension TransducerTests {
                     proxy: proxy,
                     env: T1.Env(),
                     out: Callback { output in
-                        // print(output)
+                        print(output)
                     }
                 )
                 #expect(result == (2, "finished"))


### PR DESCRIPTION
This commit adds the `sending` modifier to the parameters `initialState` in all `run()` functions.

It also fixes a failing test.