### PR TITLE
Improve task cancellation and test infrastructure

### DIFF
--- a/Sources/Oak/FSM/Context.swift
+++ b/Sources/Oak/FSM/Context.swift
@@ -53,6 +53,13 @@ final class Context {
         }
     }
     
+    func cancellAllTasks() {
+        for (_, task) in tasks.values {
+            task.cancel()
+        }
+        tasks.removeAll()
+    }
+    
     func terminate(_ error: Swift.Error) {
         terminateProxy(error)
     }

--- a/Sources/Oak/FSM/EffectTransducer.swift
+++ b/Sources/Oak/FSM/EffectTransducer.swift
@@ -165,6 +165,8 @@ extension EffectTransducer {
         } catch TransducerError.cancelled {
             // We reach here, when the transducer has been forcibly terminated
             // via the proxy, i.e. by calling `proxy.cancel()`.
+            // Eagerly cancel all tasks, if any:
+            context.cancellAllTasks()
             throw TransducerError.cancelled
         } catch {
             // We reach here, when the transducer logic failed due to some
@@ -175,14 +177,23 @@ extension EffectTransducer {
             // Caution: we do not reach here, when the current task has been
             // cancelled and has forcibly terminated the transducer.
             logger.info("Transducer '\(Self.self)' failed with error: \(error)")
+            // Eagerly cancel all tasks, if any:
+            context.cancellAllTasks()
             throw error
         }
-        // If the current task has been cancelled, we do still reach here. In
+        // The FSM reached terminal state, or the current task has been
+        // cancelled. Iff there should be running effects, we eagerly cancel
+        // them all:
+        context.cancellAllTasks()
+
+        // Iff the current task has been cancelled, we do still reach here. In
         // this case, the transducer may have been interupted being in a non-
-        // terminal state and the event buffer may still contain unprocessed
+        // terminal state and the event buffer may still containing unprocessed
         // events. We do explicitly throw a `CancellationError` to indicate
         // this fact:
         try Task.checkCancellation()
+
+        
 
 #if DEBUG
         // Here, the event buffer may still have events in it, but the transducer
@@ -252,6 +263,8 @@ extension EffectTransducer {
         } catch TransducerError.cancelled {
             // We reach here, when the transducer has been forcibly terminated
             // via the proxy, i.e. by calling `proxy.cancel()`.
+            // Eagerly cancel all tasks, if any:
+            context.cancellAllTasks()
             throw TransducerError.cancelled
         } catch {
             // We reach here, when the transducer logic failed due to some
@@ -262,11 +275,18 @@ extension EffectTransducer {
             // Caution: we do not reach here, when the current task has been
             // cancelled and has forcibly terminated the transducer.
             logger.info("Transducer '\(Self.self)' failed with error: \(error)")
+            // Eagerly cancel all tasks, if any:
+            context.cancellAllTasks()
             throw error
         }
-        // If the current task has been cancelled, we do still reach here. In
+        // The FSM reached terminal state, or the current task has been
+        // cancelled. Iff there should be running effects, we eagerly cancel
+        // them all:
+        context.cancellAllTasks()
+
+        // Iff the current task has been cancelled, we do still reach here. In
         // this case, the transducer may have been interupted being in a non-
-        // terminal state and the event buffer may still contain unprocessed
+        // terminal state and the event buffer may still containing unprocessed
         // events. We do explicitly throw a `CancellationError` to indicate
         // this fact:
         try Task.checkCancellation()

--- a/Tests/OakTests/SwiftUI/TransducerViewTests.swift
+++ b/Tests/OakTests/SwiftUI/TransducerViewTests.swift
@@ -2,7 +2,7 @@
 import Testing
 import SwiftUI
 import UIKit
-@testable import Oak
+import Oak
 
 
 /**
@@ -417,7 +417,7 @@ struct TransducerViewTests {
         
         let proxy = EventTransducer.Proxy(bufferSize: expectedCount + 2)
         var capturedInput: EventTransducer.Proxy.Input?
-        let expectation = Expectation(minFulfillCount: 10)
+        let expectation = Expectation(minFulfillCount: expectedCount)
         
         
         let view = TransducerView(

--- a/Tests/OakTests/TransducerCancellationTests.swift
+++ b/Tests/OakTests/TransducerCancellationTests.swift
@@ -29,6 +29,8 @@ import Oak
 /// `TransducerError.cancelled` error from its `run` function.
 struct TransducerCancellationTests {
     
+    // MARK: - Transducers
+    
     @MainActor
     @Test
     func cancelIdleNonTerminatingTransducerViaProxy() async throws {
@@ -63,10 +65,42 @@ struct TransducerCancellationTests {
         }
         #expect(error == TransducerError.cancelled)
     }
+    
+    @MainActor
+    @Test
+    func ensureIdleTransducerWillCancelWhenCurrentTaskIsCancelled() async throws {
+        enum T: Transducer {
+            enum State: Terminable { case start, idle, finished
+                var isTerminal: Bool { self == .finished }
+            }
+            enum Event { case start }
 
+            static func update(_ state: inout State, event: Event) {
+                if state == .start, event == .start {
+                    state = .idle
+                }
+            }
+        }
+
+        let proxy = T.Proxy()
+        try proxy.send(.start)
+        let task = Task {
+            try await T.run(initialState: .start, proxy: proxy)
+        }
+        // Give the run loop time to process the start event
+        try await Task.sleep(nanoseconds: 100_000_000)
+        task.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
+
+    // MARK: - Effect Transducers
+    
     @MainActor
     @Test("not implemented: a proxy cannot cancel an async action", .disabled())
-    func cancelSuspendedTransducerWhenInSuspendedActionViaProxy() async throws {
+    func cancelSuspendedEffectTransducerWhenInSuspendedActionViaProxy() async throws {
         enum T: EffectTransducer {
             enum State: Terminable { case start, idle, finished
                 var isTerminal: Bool { self == .finished }
@@ -105,7 +139,6 @@ struct TransducerCancellationTests {
                     }
                 )
             }
-
         }
         
         let proxy = T.Proxy()
@@ -133,7 +166,7 @@ struct TransducerCancellationTests {
 
     @MainActor
     @Test("not implemented: a proxy cannot cancel an async output subject", .disabled())
-    func cancelSuspendedTransducerWhenSuspendedInOutputViaProxy() async throws {
+    func cancelSuspendedEffectTransducerWhenSuspendedInOutputViaProxy() async throws {
         enum T: EffectTransducer {
             enum State: Terminable { case start, idle, finished
                 var isTerminal: Bool { self == .finished }
@@ -201,9 +234,10 @@ struct TransducerCancellationTests {
         #expect(error == TransducerError.cancelled)
     }
 
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     @MainActor
     @Test
-    func cancelIdleTransducerWhenRunningAsynchronousEffectsWithOutputViaProxy() async throws {
+    func cancelIdleEffectTransducerWhenRunningAsynchronousEffectsWithOutputViaProxy() async throws {
         enum T: EffectTransducer {
             
             enum State: Terminable { 
@@ -218,7 +252,11 @@ struct TransducerCancellationTests {
                 let isWaiting: Bool
             }
             
-            struct Env {}
+            struct Env {
+                let effectStarted = Expectation()
+                let expectOutput = Expectation()
+                let expectCancelled = Expectation()
+            }
             
             static func update(_ state: inout State, event: Event) -> (T.Effect?, Output) {
                 switch (state, event) {
@@ -244,12 +282,16 @@ struct TransducerCancellationTests {
 
             static func makeOperationEffect() -> T.Effect {
                 T.Effect(
-                    operation: { _, input in
+                    operation: { env, input in
                         do {
-                            try await Task.sleep(nanoseconds: 100_000_000_000) // 100 seconds
+                            env.effectStarted.fulfill()
+                            while true {
+                                try await Task.sleep(nanoseconds: 1_000_000_000) // 1 seconds
+                            }
                             #expect(Bool(false), "Effect should have been cancelled")
                             try input.send(.ready)
                         } catch {
+                            env.expectCancelled.fulfill()
                             #expect(error is CancellationError, "Expected CancellationError, got \(type(of: error))")
                             throw error // Re-throw to propagate the cancellation
                         }
@@ -260,36 +302,41 @@ struct TransducerCancellationTests {
         
         let proxy = T.Proxy()
         try proxy.send(.start) // This should trigger the long-running effect
+        let env = T.Env()
         
         let task = Task {
             try await T.run(
                 initialState: .start,
                 proxy: proxy,
-                env: T.Env(),
+                env: env,
                 output: Callback { @MainActor output in
-                    print("Output: value=\(output.value), pending=\(output.isWaiting)")
+                    if output.isWaiting {
+                        env.expectOutput.fulfill()
+                    }
                 }
             )
         }
         
         Task {
-            try await Task.sleep(nanoseconds: 1_000_000)
+            try await env.effectStarted.await(timeout: .seconds(10))
             // Given:
             //  - the event buffer contains no events
             //  - the transducer is running a long-running effect (waiting 100 seconds)
             // Then cancel:
             proxy.cancel()
         }
-        
+        try await env.expectCancelled.await(timeout: .seconds(10000))
+        try await env.expectOutput.await(timeout: .seconds(10000))
         let error = await #expect(throws: TransducerError.self) {
             try await task.value
         }
         #expect(error == TransducerError.cancelled)
     }
 
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     @MainActor
     @Test
-    func cancelIdleTransducerWhenRunningAsynchronousEffectsViaProxy() async throws {
+    func cancelIdleEffectTransducerWhenRunningAsynchronousEffectsViaProxy() async throws {
         enum T: EffectTransducer {
             
             enum State: Terminable {
@@ -299,7 +346,10 @@ struct TransducerCancellationTests {
             
             enum Event { case start, ready }
             
-            struct Env {}
+            struct Env {
+                let effectStarted = Expectation()
+                let effectCancelled = Expectation()
+            }
             
             static func update(_ state: inout State, event: Event) -> T.Effect? {
                 switch (state, event) {
@@ -324,13 +374,20 @@ struct TransducerCancellationTests {
 
             static func makeEffect() -> T.Effect {
                 T.Effect(
-                    operation: { _, input in
+                    operation: { env, input in
                         do {
-                            try await Task.sleep(nanoseconds: 100_000_000_000) // 100 seconds
+                            env.effectStarted.fulfill()
+                            while true {
+                                try await Task.sleep(nanoseconds: 1_000_000_000) // 1 seconds
+                            }
                             #expect(Bool(false), "Effect should have been cancelled")
                             try input.send(.ready)
                         } catch {
-                            #expect(error is TransducerError, "Expected TransducerError.cancelled, got \(type(of: error))")
+                            // When a transducer gets cancelled, it's operations
+                            // running in a task. This task will be cancelld, so
+                            // we get a `CancellationError`
+                            env.effectCancelled.fulfill()
+                            #expect(error is CancellationError, "Expected CancellationError, got \(type(of: error))")
                             throw error // Re-throw to propagate the cancellation
                         }
                     }
@@ -340,55 +397,203 @@ struct TransducerCancellationTests {
         
         let proxy = T.Proxy()
         try proxy.send(.start) // This should trigger the long-running effect
+        let env = T.Env()
         
         let task = Task {
             try await T.run(
                 initialState: .start,
                 proxy: proxy,
-                env: T.Env()
+                env: env
             )
         }
         
         Task {
-            try await Task.sleep(nanoseconds: 1_000_000)
+            try await env.effectStarted.await(timeout: .seconds(10))
             // Given:
             //  - the event buffer contains no events
             //  - the transducer is running a long-running effect (waiting 100 seconds)
             // Then cancel:
             proxy.cancel()
         }
-        
+        try await env.effectCancelled.await(timeout: .seconds(10))
         let error = await #expect(throws: TransducerError.self) {
             try await task.value
         }
         #expect(error == TransducerError.cancelled)
     }
 
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     @MainActor
     @Test
-    func ensureIdleTransducerWillCancelWhenCurrentTaskIsCancelled() async throws {
-        enum T: Transducer {
-            enum State: Terminable { case start, idle, finished
+    func cancelIdleEffectTransducerWhenRunningAsynchronousEffectsWhenCurrentTaskIsCancelled() async throws {
+        enum T: EffectTransducer {
+            
+            enum State: Terminable {
+                case start, idle, waiting, finished
                 var isTerminal: Bool { self == .finished }
             }
-            enum Event { case start }
-
-            static func update(_ state: inout State, event: Event) {
-                if state == .start, event == .start {
+            
+            enum Event { case start, ready }
+            
+            struct Env {
+                let effectStarted = Expectation()
+                let effectCancelled = Expectation()
+            }
+            
+            static func update(_ state: inout State, event: Event) -> T.Effect? {
+                switch (state, event) {
+                case (.start, .start):
+                    state = .waiting
+                    return makeEffect()
+                case (.waiting, .ready):
                     state = .idle
+                    return nil
+                case (.idle, .start):
+                    return nil
+                case (.finished, _):
+                    return nil
+                case (.idle, .ready):
+                    return nil
+                case (.start, .ready):
+                    return nil
+                case (.waiting, .start):
+                    return nil
                 }
             }
-        }
 
+            static func makeEffect() -> T.Effect {
+                T.Effect(
+                    operation: { env, input in
+                        do {
+                            env.effectStarted.fulfill()
+                            while true {
+                                try await Task.sleep(nanoseconds: 100_000_000_000) // 100 seconds
+                            }
+                            #expect(Bool(false), "Effect should have been cancelled")
+                            try input.send(.ready)
+                        } catch {
+                            env.effectCancelled.fulfill()
+                            #expect(error is CancellationError, "Expected CancellationError, got \(type(of: error))")
+                            throw error // Re-throw to propagate the cancellation
+                        }
+                    }
+                )
+            }
+        }
+        
         let proxy = T.Proxy()
-        try proxy.send(.start)
+        try proxy.send(.start) // This should trigger the long-running effect
+        let env = T.Env()
+        
         let task = Task {
-            try await T.run(initialState: .start, proxy: proxy)
+            try await T.run(
+                initialState: .start,
+                proxy: proxy,
+                env: env
+            )
+            print("done")
         }
-        // Give the run loop time to process the start event
-        try await Task.sleep(nanoseconds: 1_000_000)
-        task.cancel()
+        
+        try await env.effectStarted.await(timeout: .seconds(10))
+        // Given:
+        //  - the event buffer contains no events
+        //  - the transducer is running a long-running effect (waiting 100 seconds)
+        // Then cancel the task:
+        Task {
+            task.cancel()
+        }
 
+        try await env.effectCancelled.await(timeout: .seconds(10))
+        
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
+
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+    @MainActor
+    @Test
+    func cancelIdleEffectTransducerWhenRunningAsynchronousEffectsWithOutputWhenCurrentTaskIsCancelled() async throws {
+        enum T: EffectTransducer {
+            
+            enum State: Terminable {
+                case start, idle, waiting, finished
+                var isTerminal: Bool { self == .finished }
+            }
+            
+            enum Event { case start, ready }
+            
+            struct Env {
+                let effectStarted = Expectation()
+                let effectCancelled = Expectation()
+            }
+            
+            typealias Output = Int
+            
+            static func update(_ state: inout State, event: Event) -> (T.Effect?, Output) {
+                switch (state, event) {
+                case (.start, .start):
+                    state = .waiting
+                    return (makeEffect(), 0)
+                case (.waiting, .ready):
+                    state = .idle
+                    return (nil, 1)
+                case (.idle, .start):
+                    return (nil, 2)
+                case (.finished, _):
+                    return (nil, 3)
+                case (.idle, .ready):
+                    return (nil, 4)
+                case (.start, .ready):
+                    return (nil, 5)
+                case (.waiting, .start):
+                    return (nil, 6)
+                }
+            }
+
+            static func makeEffect() -> T.Effect {
+                T.Effect(
+                    operation: { env, input in
+                        do {
+                            env.effectStarted.fulfill()
+                            while true {
+                                try await Task.sleep(nanoseconds: 1_000_000_000) // 1 seconds
+                            }
+                            #expect(Bool(false), "Effect should have been cancelled")
+                            try input.send(.ready)
+                        } catch {
+                            env.effectCancelled.fulfill()
+                            #expect(error is CancellationError, "Expected CancellationError, got \(type(of: error))")
+                            throw error // Re-throw to propagate the cancellation
+                        }
+                    }
+                )
+            }
+        }
+        
+        let proxy = T.Proxy()
+        try proxy.send(.start) // This should trigger the long-running effect
+        let env = T.Env()
+        
+        let task = Task {
+            try await T.run(
+                initialState: .start,
+                proxy: proxy,
+                env: env
+            )
+        }
+        
+        try await env.effectStarted.await(timeout: .seconds(10))
+        // Given:
+        //  - the event buffer contains no events
+        //  - the transducer is running a long-running effect (waiting 100 seconds)
+        // Then cancel the task:
+        Task {
+            task.cancel()
+        }
+
+        try await env.effectCancelled.await(timeout: .seconds(10))
+        
         await #expect(throws: CancellationError.self) {
             try await task.value
         }
@@ -418,7 +623,7 @@ struct TransducerCancellationTests {
             try await T.run(initialState: .start, proxy: proxy, env: T.Env())
         }
         // Give the run loop time to process the start event
-        try await Task.sleep(nanoseconds: 1_000_000)
+        try await Task.sleep(nanoseconds: 100_000_000)
         task.cancel()
 
         await #expect(throws: CancellationError.self) {
@@ -426,6 +631,7 @@ struct TransducerCancellationTests {
         }
     }
 
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     @MainActor
     @Test
     func ensureSuspendedEffectTransducerWillCancelWhenCurrentTaskIsCancelled() async throws {
@@ -434,19 +640,26 @@ struct TransducerCancellationTests {
                 var isTerminal: Bool { self == .finished }
             }
             enum Event { case start, ready }
-            struct Env {}
+            struct Env {
+                let effectStarted = Expectation()
+                let effectCancelled = Expectation()
+            }
 
             static func update(_ state: inout State, event: Event) -> Self.Effect? {
                 if state == .start, event == .start {
                     state = .idle
-                    return T.Effect(action: { _ in
+                    return T.Effect(action: { env in
                         do {
-                            try await Task.sleep(nanoseconds: 1_000_000_000)
+                            env.effectStarted.fulfill()
+                            while true {
+                                try await Task.sleep(nanoseconds: 1_000_000_000)
+                            }
                             // Should never reach here
                             #expect(Bool(false), "Effect action should have been cancelled before completion")
                             return [.ready]
                         } catch {
                             #expect(error is CancellationError, "Expected CancellationError in effect action, got \(type(of: error))")
+                            env.effectCancelled.fulfill()
                             throw error
                         }
                     })
@@ -457,45 +670,57 @@ struct TransducerCancellationTests {
 
         let proxy = T.Proxy()
         try proxy.send(.start)
+        let env = T.Env()
         let task = Task {
-            try await T.run(initialState: .start, proxy: proxy, env: T.Env())
+            try await T.run(initialState: .start, proxy: proxy, env: env)
         }
-        // Give the run loop time to start the effect
-        try await Task.sleep(nanoseconds: 1_000_000)
+        // wait until the effect started:
+        try await env.effectStarted.await(timeout: .seconds(10))
         // Cancel the outer task
         task.cancel()
 
+        try await env.effectCancelled.await(timeout: .seconds(10))
         // The run function should throw a CancellationError
         await #expect(throws: CancellationError.self) {
             try await task.value
         }
     }
 
+    @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     @MainActor
     @Test
     func ensureIdleEffectTransducerWithRunningEffectWillCancelWhenCurrentTaskIsCancelled() async throws {
+        
         enum T: EffectTransducer {
             enum State: Terminable {
                 case start, idle, finished
                 var isTerminal: Bool { self == .finished }
             }
             enum Event { case start, ready }
-            struct Env {}
+            struct Env {
+                let effectStarted = Expectation()
+                let effectCancelled = Expectation()
+            }
 
             static func update(_ state: inout State, event: Event) -> Self.Effect? {
                 switch (state, event) {
                 case (.start, .start):
                     state = .idle
-                    return Effect { _, input in
+                    return Effect { env, input in
                         do {
+                            env.effectStarted.fulfill()
                             // Suspend for 1 second
-                            try await Task.sleep(nanoseconds: 1_000_000_000)
+                            while true {
+                                // We effectively check for cancellation every 1 sec
+                                try await Task.sleep(nanoseconds: 1_000_000_000)
+                            }
                             // Should never get here
                             #expect(Bool(false), "Effect operation should have been cancelled before completing")
                             try input.send(.ready)
                         } catch {
                             // Expect a CancellationError when task is cancelled
                             #expect(error is CancellationError, "Expected CancellationError in effect, got \(type(of: error))")
+                            env.effectCancelled.fulfill()
                             throw error
                         }
                     }
@@ -508,16 +733,18 @@ struct TransducerCancellationTests {
 
         let proxy = T.Proxy()
         try proxy.send(.start)
+        let env = T.Env()
 
         let task = Task {
-            try await T.run(initialState: .start, proxy: proxy, env: T.Env())
+            try await T.run(initialState: .start, proxy: proxy, env: env)
         }
-
+        
         // Give the transducer time to start the effect
-        try await Task.sleep(nanoseconds: 1_000_000)
+        try await env.effectStarted.await(timeout: .seconds(10))
         // Cancel the outer task
         task.cancel()
 
+        try await env.effectCancelled.await(timeout: .seconds(10))
         // The run() should throw a CancellationError
         await #expect(throws: CancellationError.self) {
             try await task.value
@@ -526,7 +753,7 @@ struct TransducerCancellationTests {
     
     @MainActor
     @Test
-    func ensureIdleEffectTransducerWillCancelWhenCurrentTaskIsCancelled2() async throws {
+    func ensureIdleEffectTransducerWithOutputWillCancelWhenCurrentTaskIsCancelled() async throws {
         enum T: EffectTransducer {
             enum State: Terminable { case start, idle, finished
                 var isTerminal: Bool { self == .finished }
@@ -545,11 +772,12 @@ struct TransducerCancellationTests {
 
         let proxy = T.Proxy()
         try proxy.send(.start)
+        let env = T.Env()
         let task = Task {
-            try await T.run(initialState: .start, proxy: proxy, env: T.Env())
+            try await T.run(initialState: .start, proxy: proxy, env: env)
         }
         // Give the run loop time to process the start event
-        try await Task.sleep(nanoseconds: 1_000_000)
+        try await Task.sleep(nanoseconds: 100_000_000)
         task.cancel()
 
         await #expect(throws: CancellationError.self) {


### PR DESCRIPTION
- Add eager task cancellation in EffectTransducer for all termination
      paths.
- Implement cancellAllTasks() in Context for immediate cleanup.
- Enhance TransducerCancellationTests with deterministic synchronization.
- Replace sleep-based timing with Expectation framework in tests.
- Add comprehensive cancellation scenarios for both proxy and task
      cancellation.
- Fix expectation count in TransducerViewTests.
    
    This commit ensures that resources held by running effects will be
    released more eagerly after cancellation or termination of the
    transducer and also ensures a more predictable lifecycle management.