### PR TITLE
docs: Add comprehensive protocol documentation and rename for semanti…

### DIFF
--- a/Sources/Oak/FSM/AsyncProxy.swift
+++ b/Sources/Oak/FSM/AsyncProxy.swift
@@ -1,12 +1,12 @@
 import AsyncAlgorithms
 import struct Foundation.UUID
 
-/// `AsyncProxy` is a proxy that sends events into the system using
-/// an  async non-throwing function.
+/// `SyncSuspendingProxy` is a proxy that sends events into the system using
+/// an async non-throwing function.
 ///
-/// When explicitly defining the Proxy type `Oak.AsyncProxy<Event>`
-/// in the `EventTransducer`, we are using an `AsyncProxy` for sending
-/// events into the system. This event delivery mechansism uses an async
+/// When explicitly defining the Proxy type `Oak.SyncSuspendingProxy<Event>`
+/// in the `EventTransducer`, we are using a `SyncSuspendingProxy` for sending
+/// events into the system. This event delivery mechanism uses an async
 /// function to deliver the event that suspends until after the event
 /// has been processed. This also includes being suspended until the
 /// delivery of an output value (through a Subject) has been completed.
@@ -15,7 +15,7 @@ import struct Foundation.UUID
 /// The processing speed of the transducer will be dynamically adjusted
 /// so that it is synchronised with its event producers and its output
 /// consumers through utilising suspension.
-public struct AsyncProxy<Event: Sendable>: TransducerProxy {
+public struct SyncSuspendingProxy<Event: Sendable>: TransducerProxy {
     public let id: UUID = UUID()
     
     enum Error: Swift.Error {
@@ -25,7 +25,7 @@ public struct AsyncProxy<Event: Sendable>: TransducerProxy {
     
     public let stream: AsyncThrowingChannel<Event, Swift.Error>
             
-    public struct Input: AsyncTransducerInput {
+    public struct Input: SyncSuspendingTransducerInput {
         let channel: AsyncThrowingChannel<Event, Swift.Error>
         
         public func send(_ event: Event) async {
@@ -39,15 +39,15 @@ public struct AsyncProxy<Event: Sendable>: TransducerProxy {
         }
 
         let stream: Stream
-        let id: AsyncProxy.ID
+        let id: SyncSuspendingProxy.ID
 
-        init(proxy: AsyncProxy) {
+        init(proxy: SyncSuspendingProxy) {
             stream = proxy.stream
             id = proxy.id
         }
         
         deinit {
-            stream.fail(AsyncProxy<Event>.Error.deinitialised)
+            stream.fail(SyncSuspendingProxy<Event>.Error.deinitialised)
         }
     }
 

--- a/Sources/Oak/FSM/BaseTransducer.swift
+++ b/Sources/Oak/FSM/BaseTransducer.swift
@@ -47,7 +47,7 @@ public protocol BaseTransducer<Event> {
     /// a "fire & forget" style of event sending and also requires an internal
     /// event buffer. Sending may fail if the buffer is full.
     /// 
-    /// The other built-in proxy is `AsyncProxy<Event>`, which provides
+    /// The other built-in proxy is `SyncSuspendingProxy<Event>`, which provides
     /// an async interface for sending events. This interface suspends until
     /// the event has been processed. It does not require an internal event
     /// buffer and sending also cannot fail. This effectively implements

--- a/Sources/Oak/FSM/Completable.swift
+++ b/Sources/Oak/FSM/Completable.swift
@@ -1,0 +1,56 @@
+
+/// A type which observes a completion notification.
+///
+/// A completion value is used as a parameter and set by the caller when
+/// using a transducer actor.  When the transducer completes, the completion
+/// value acts accordingly, usually calling a closure that has been providedy
+/// in the completion's initialiser.
+///
+/// Types which conform to `TransducerActor` should implement
+/// a concrete type which fulfills the requirements of their implemention.
+///
+/// > Note: The corresponding `Completion` type is already implemented
+/// for `TransducerView` and `ObservableTransducer`.
+///
+/// ## Example
+///
+/// The example below shows an implementation for a transducer actor which
+/// is runnnig on the MainActor, such as an Observable or a SwiftUI View.
+///
+/// ```swift
+/// public struct Completion: @MainActor Oak.Completable {
+///     public typealias Value = Output
+///     public typealias Failure = Error
+///
+///     let f: (Result<Value, Failure>) -> Void
+///
+///     public init(
+///         _ onCompletion: @escaping(
+///             Result<Value, Failure>
+///         ) -> Void
+///     ) {
+///         f = onCompletion
+///     }
+///     public func completed(
+///         with result: Result<Value, Failure>
+///     ) {
+///         f(result)
+///     }
+///
+///     func before(
+///         g: @escaping (
+///             Result<Value, Failure>
+///         ) -> Result<Value, Failure>
+///     ) -> Self {
+///         .init { result in
+///             self.f(g(result))
+///         }
+///     }
+/// }
+///```
+public protocol Completable<Value, Failure> {
+    associatedtype Value
+    associatedtype Failure: Error
+
+    func completed(with: Result<Value, Failure>)
+}

--- a/Sources/Oak/FSM/Proxy.swift
+++ b/Sources/Oak/FSM/Proxy.swift
@@ -97,7 +97,7 @@ public struct Proxy<Event>: TransducerProxy, Identifiable {
     /// 
     /// It is designed to be used within effects or other asynchronous contexts
     /// where you need to send events back to the transducer.
-    public struct Input: TransducerInput {
+    public struct Input: BufferedTransducerInput {
         
         internal init(continuation: Continuation) {
             self.continuation = continuation

--- a/Sources/Oak/FSM/Storage.swift
+++ b/Sources/Oak/FSM/Storage.swift
@@ -1,3 +1,8 @@
+/// A protocol that abstracts different storage implementations for transducer state.
+///
+/// This protocol is used internally by the Oak framework to provide a unified interface
+/// for various storage types including local storage, KeyPath-based storage, and SwiftUI Bindings.
+/// Users typically won't interact with this protocol directly.
 public protocol Storage<Value> {
     associatedtype Value
     

--- a/Sources/Oak/FSM/Subject.swift
+++ b/Sources/Oak/FSM/Subject.swift
@@ -1,5 +1,54 @@
 
 /// A type that can receive values and send it to a destination.
+///
+/// ## Overview
+///
+/// The `Subject` protocol serves as the output facility for transducers, providing a unified API
+/// for transducers to send values without knowing the specific implementation details of how those
+/// values are consumed or processed.
+///
+/// From the transducer's perspective, this protocol offers a simple interface to emit output values.
+/// From the user's perspective, this abstraction allows for flexible consumption patterns through
+/// various concrete implementations.
+///
+/// ## Common Implementations
+///
+/// The Oak library provides built-in implementations:
+///
+/// - **`Callback`**: Direct function-based value consumption
+/// - **`NoCallback`**: A no-op implementation for when output values should be discarded
+///
+/// Additional implementations can include:
+///
+/// - **AsyncStream**: Stream-based asynchronous value consumption  
+/// - **Combine Subject**: Integration with the Combine framework for reactive programming
+/// - **Custom Consumers**: Any type that needs to consume values from a transducer
+///
+/// ## Usage Pattern
+///
+/// Transducers use this protocol to emit output values without coupling to specific consumption mechanisms:
+///
+/// ```swift
+/// // Transducer sends output through the subject
+/// try await output.send(computedValue, isolated: systemActor)
+/// ```
+///
+/// Users can provide different subject implementations based on their consumption needs:
+///
+/// ```swift
+/// // Using the provided Callback type
+/// let callback = Callback<String> { value in
+///     print("Received: \(value)")
+/// }
+///
+/// // Using NoCallback when output should be discarded
+/// let noOutput = NoCallback<String>()
+///
+/// // Using with an AsyncStream
+/// let (stream, continuation) = AsyncStream.makeStream(of: String.self)
+/// let streamSubject = AsyncStreamSubject(continuation)
+/// ```
+///
 public protocol Subject<Value> {
     /// The type of the input value.
     associatedtype Value

--- a/Sources/Oak/FSM/Terminable.swift
+++ b/Sources/Oak/FSM/Terminable.swift
@@ -1,7 +1,67 @@
-/// Used to conform Transducer _State_.
+/// A protocol used to conform transducer _State_ types, defining terminal states in finite state automata.
 ///
-/// A state is considered terminal if it cannot transition to 
-/// any other state.
+/// ## Overview
+///
+/// The `Terminable` protocol is a fundamental concept from classical finite state automaton (FSA) theory,
+/// implemented here to control transducer execution flow. A state is considered terminal if it cannot
+/// transition to any other state, effectively marking the end of the transducer's computation.
+///
+/// ## Finite State Automaton Context
+///
+/// In classical FSA theory, terminal (or final/accepting) states represent points where the automaton
+/// has successfully completed its computation. The Oak framework uses this concept to:
+///
+/// - **Control Execution**: Transducers automatically terminate when reaching a terminal state
+/// - **Resource Management**: Allows proper cleanup and resource deallocation
+/// - **Completion Semantics**: Provides clear success/completion indicators for business logic
+///
+/// ## Implementation Patterns
+///
+/// ### Explicit Terminal States
+/// ```swift
+/// enum ProcessState: Terminable {
+///     case idle
+///     case processing
+///     case completed  // Terminal state
+///     case failed     // Terminal state
+///     
+///     var isTerminal: Bool {
+///         switch self {
+///         case .completed, .failed:
+///             return true
+///         case .idle, .processing:
+///             return false
+///         }
+///     }
+/// }
+/// ```
+///
+/// ### Using NonTerminal for Convenience
+/// ```swift
+/// // For states that are never terminal
+/// enum ActiveState: NonTerminal {
+///     case waiting
+///     case active
+///     case suspended
+///     // isTerminal automatically returns false
+/// }
+/// ```
+///
+/// ## Transducer Integration
+///
+/// When a transducer's state becomes terminal:
+/// 1. **Execution Stops**: No further state transitions are processed
+/// 2. **Completion Callbacks**: Any registered completion handlers are invoked
+/// 3. **Resource Cleanup**: The transducer task terminates and releases resources
+/// 4. **Final Output**: Any final output values are emitted before termination
+///
+/// ## Design Considerations
+///
+/// - **Immutable Semantics**: Terminal status should be determined by the state value itself
+/// - **Clear Boundaries**: Terminal states should represent logical completion points
+/// - **Error States**: Failed states are typically terminal to prevent invalid transitions
+/// - **Success States**: Completed/success states are terminal to indicate successful completion
+///
 public protocol Terminable {
     var isTerminal: Bool { get }
 }
@@ -10,6 +70,38 @@ extension Terminable {
 }
 
 
+/// A convenience protocol for states that are never terminal.
+///
+/// ## Overview
+///
+/// `NonTerminal` provides a default implementation of `Terminable` that always returns `false`
+/// for `isTerminal`. This is useful for state types where no states should ever be terminal,
+/// eliminating the need to manually implement `isTerminal` for each case.
+///
+/// ## Usage
+///
+/// Use `NonTerminal` when your state machine represents ongoing processes that don't have
+/// natural completion points within the state definition itself:
+///
+/// ```swift
+/// enum UIState: NonTerminal {
+///     case loading
+///     case displaying(content: String)
+///     case editing
+///     // All states are non-terminal by default
+/// }
+/// ```
+///
+/// This is equivalent to manually implementing:
+/// ```swift
+/// enum UIState: Terminable {
+///     case loading
+///     case displaying(content: String)
+///     case editing
+///     
+///     var isTerminal: Bool { false }
+/// }
+/// ```
 public protocol NonTerminal: Terminable {}
 
 extension NonTerminal {

--- a/Sources/Oak/FSM/TransducerInput.swift
+++ b/Sources/Oak/FSM/TransducerInput.swift
@@ -1,6 +1,88 @@
-/// Represents the input interface for a transducer in a 
-/// finite state machine (FSM).
-public protocol AsyncTransducerInput<Event>: Sendable {
+/// Represents the input interface for a transducer in a finite state machine (FSM).
+///
+/// ## Overview
+///
+/// The `SyncSuspendingTransducerInput` protocol is a fundamental concept from classical finite state automaton 
+/// (FSA) theory, representing the input alphabet and event delivery mechanism. In FSA theory, inputs 
+/// drive state transitions, making this protocol crucial for transducer operation.
+///
+/// ## Key Features
+///
+/// ### Execution Semantics: "Synchronous and Suspending"
+/// `SyncSuspendingTransducerInput` provides **synchronous computation semantics**:
+/// - **Suspends** until the transducer's computation completes
+/// - **Waits** for all action effects to finish
+/// - **Waits** for any output values to be sent
+/// - **Guarantees** the event has been fully processed before returning
+///
+/// This provides strong consistency guarantees but may impact performance in high-throughput scenarios.
+///
+/// ### Sendable Value Semantics
+/// Unlike traditional input mechanisms, `SyncSuspendingTransducerInput` is a `Sendable` value type that can be:
+/// - **Copied freely**: Multiple references can exist without ownership concerns
+/// - **Used anywhere**: Safe to pass across actor boundaries and concurrent contexts
+/// - **Shared safely**: No synchronization required for access
+///
+/// ### Composable System Architecture
+/// The copyable, sendable nature makes it extremely handy for building and composing systems of 
+/// transducers where:
+/// - One transducer's output connects to another's input
+/// - Event distribution to multiple transducers
+/// - Complex transducer networks and pipelines
+///
+/// ## Usage Patterns
+///
+/// ### Direct Event Sending
+/// ```swift
+/// // Simple event delivery
+/// await input.send(.userAction)
+/// await input.send(.dataReceived(data))
+/// ```
+///
+/// ### Transducer Composition
+/// ```swift
+/// // Connect transducer outputs to inputs
+/// struct ComposedSystem {
+///     let processorInput: some SyncSuspendingTransducerInput<ProcessEvent>
+///     let displayInput: some SyncSuspendingTransducerInput<DisplayEvent>
+///     
+///     func handleProcessorOutput(_ output: ProcessResult) async {
+///         // Transform and forward to display transducer
+///         await displayInput.send(.showResult(output))
+///     }
+/// }
+/// ```
+///
+/// ### Multi-cast Event Distribution
+/// ```swift
+/// // Share input across multiple consumers
+/// let sharedInput = transducer.input
+/// let inputCopy1 = sharedInput  // Safe to copy
+/// let inputCopy2 = sharedInput  // Each copy is independent
+/// 
+/// // Use from different contexts
+/// Task { await inputCopy1.send(.event1) }
+/// Task { await inputCopy2.send(.event2) }
+/// ```
+///
+/// ## Finite State Automaton Context
+///
+/// In classical FSA theory, the input represents:
+/// - **Input Alphabet (Σ)**: The set of possible events/symbols
+/// - **Transition Function**: Events trigger state transitions δ(state, input) → state
+/// - **Event Sequence**: The ordered sequence of inputs that drive computation
+///
+/// The Oak framework extends this concept with modern concurrency and composition capabilities
+/// while maintaining the theoretical foundation.
+///
+/// ## Error Handling
+///
+/// Events may fail to be delivered in scenarios such as:
+/// - Transducer has reached a terminal state
+/// - Event buffer overflow (if buffering is used)
+/// - Invalid event for current state (implementation-dependent)
+///
+public protocol SyncSuspendingTransducerInput<Event>: Sendable {
     associatedtype Event
     
     /// Sends an event to the transducer.
@@ -13,9 +95,71 @@ public protocol AsyncTransducerInput<Event>: Sendable {
 }
 
 
-/// Represents the input interface for a transducer in a
-/// finite state machine (FSM).
-public protocol TransducerInput<Event>: Sendable {
+/// Represents the buffered input interface for a transducer in a finite state machine (FSM).
+///
+/// ## Overview
+///
+/// `BufferedTransducerInput` provides a buffered, non-suspending input mechanism that contrasts with 
+/// `SyncSuspendingTransducerInput`'s synchronous computation semantics.
+///
+/// ### Execution Semantics: "Asynchronous and Non-Suspending"
+/// `BufferedTransducerInput` provides **asynchronous computation semantics**:
+/// - **Enqueues** events into an internal buffer
+/// - **Returns immediately** without waiting for computation
+/// - **Computation happens asynchronously** in the background
+/// - **Higher throughput** due to buffering and immediate return
+///
+/// This provides better performance for high-throughput scenarios but with weaker consistency guarantees.
+///
+/// ## Comparison with SyncSuspendingTransducerInput
+///
+/// | Aspect | `BufferedTransducerInput` | `SyncSuspendingTransducerInput` |
+/// |--------|---------------------------|---------------------------------|
+/// | **Execution** | Asynchronous & Non-Suspending | Synchronous & Suspending |
+/// | **Buffering** | Internal event buffer | Direct computation |
+/// | **Return Timing** | Immediate (after enqueue) | After full computation |
+/// | **Throughput** | Higher (buffered) | Lower (synchronous) |
+/// | **Consistency** | Eventual | Strong |
+/// | **Use Cases** | High-volume events | Guaranteed completion |
+///
+/// ## Naming Clarification
+///
+/// The new naming scheme is self-documenting:
+/// - `BufferedTransducerInput` → **Buffered, asynchronous computation** (events queued, immediate return)
+/// - `SyncSuspendingTransducerInput` → **Synchronous computation with suspension** (waits for completion)
+///
+/// ## Usage
+///
+/// Prefer `BufferedTransducerInput` when:
+/// - **High throughput** is required
+/// - **Fire-and-forget** semantics are acceptable
+/// - **Buffering** events is beneficial
+/// - Working in **synchronous contexts** (no `async`/`await`)
+///
+/// ```swift
+/// // Events are buffered and processed asynchronously
+/// do {
+///     try input.send(.highVolumeEvent1)
+///     try input.send(.highVolumeEvent2)
+///     try input.send(.highVolumeEvent3)
+///     // All events enqueued immediately, processing happens in background
+/// } catch {
+///     // Handle buffer overflow or termination
+/// }
+/// ```
+///
+/// Prefer `SyncSuspendingTransducerInput` when:
+/// - **Guaranteed completion** before proceeding is required
+/// - **Strong consistency** is needed
+/// - **Coordination** with computation results is necessary
+///
+/// ```swift
+/// // Wait for complete processing before continuing
+/// await syncInput.send(.criticalEvent)
+/// // Event is fully processed, effects completed, outputs sent
+/// ```
+///
+public protocol BufferedTransducerInput<Event>: Sendable {
     associatedtype Event
     
     /// Sends an event to the transducer.

--- a/Tests/OakTests/ProxyDefaultConstructorTests.swift
+++ b/Tests/OakTests/ProxyDefaultConstructorTests.swift
@@ -23,10 +23,10 @@ struct ProxyDefaultConstructorTests {
     }
     
     @Test
-    func asyncProxyHasDefaultConstructor() {
-        // Test that AsyncProxy also has default constructor
-        let asyncProxy = Oak.AsyncProxy<String>()
-        #expect(asyncProxy.id != UUID(uuidString: "00000000-0000-0000-0000-000000000000"))
+    func syncSuspendingProxyHasDefaultConstructor() {
+        // Test that SyncSuspendingProxy also has default constructor
+        let syncSuspendingProxy = Oak.SyncSuspendingProxy<String>()
+        #expect(syncSuspendingProxy.id != UUID(uuidString: "00000000-0000-0000-0000-000000000000"))
     }
     
     @Test
@@ -50,12 +50,12 @@ struct ProxyDefaultConstructorTests {
     }
     
     @Test 
-    func asyncProxyConstructorDoesNotHang() async throws {
-        // Just test that we can construct the async proxy without hanging
-        let asyncProxy = Oak.AsyncProxy<String>()
+    func syncSuspendingProxyConstructorDoesNotHang() async throws {
+        // Just test that we can construct the sync suspending proxy without hanging
+        let syncSuspendingProxy = Oak.SyncSuspendingProxy<String>()
         
         // Test that the proxy has a valid ID (non-nil UUID)
-        #expect(asyncProxy.id != UUID(uuidString: "00000000-0000-0000-0000-000000000000"))
+        #expect(syncSuspendingProxy.id != UUID(uuidString: "00000000-0000-0000-0000-000000000000"))
         
         // The test passes if we reach here without hanging on construction
         #expect(true)

--- a/Tests/OakTests/SwiftUI/TransducerViewTests.swift
+++ b/Tests/OakTests/SwiftUI/TransducerViewTests.swift
@@ -490,7 +490,7 @@ struct TransducerViewTests {
     
     @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
     @Test
-    func inputEventsReachTransducerUsingAsyncProxy() async throws {
+    func inputEventsReachTransducerUsingSyncSuspendingProxy() async throws {
         enum Output {
             case receivedEvent(String)
         }
@@ -508,7 +508,7 @@ struct TransducerViewTests {
                 return .receivedEvent("")
             }
             
-            typealias Proxy = Oak.AsyncProxy<Event>
+            typealias Proxy = Oak.SyncSuspendingProxy<Event>
         }
         
         var receivedEvents: [String] = []
@@ -539,9 +539,9 @@ struct TransducerViewTests {
         let (_, window) = await embedInWindowAndMakeKey(view)
 
         // Note:
-        // When explicitly defining the Proxy type `Oak.AsyncProxy<Event>`
-        // in the `EventTransducer`, we are using an `AsyncProxy` for sending
-        // events into the system. This event delivery mechansism uses an async
+        // When explicitly defining the Proxy type `Oak.SyncSuspendingProxy<Event>`
+        // in the `EventTransducer`, we are using a `SyncSuspendingProxy` for sending
+        // events into the system. This event delivery mechanism uses an async
         // function to deliver the event that suspends until after the event
         // has been processed. This also includes being suspended until the
         // delivery of an output value (through a Subject) has been completed.


### PR DESCRIPTION
…c clarity

- Add extensive documentation for core protocols with FSA theory foundation
  * TransducerActor: Complete protocol documentation with usage patterns
  * Storage: Concise internal protocol documentation
  * Subject: Comprehensive output facility documentation with Oak types
  * Terminable: FSA theory documentation with implementation patterns
  * Add Completable protocol for completion semantics

- Rename protocols to eliminate confusing async/sync semantic inversion
  * AsyncTransducerInput → SyncSuspendingTransducerInput
  * TransducerInput → BufferedTransducerInput
  * AsyncProxy → SyncSuspendingProxy
  * Update all internal references and type aliases

- Update test documentation and references to use new consistent naming
  * Update TransducerViewTests and ProxyDefaultConstructorTests
  * Maintain functionality while improving semantic clarity

All protocols now have self-documenting names with comprehensive documentation connecting classical FSA theory to practical Oak framework implementation.