### PR TITLE
fix(fsm): more eager Task cancellation in TransducerActor, correct un…

### DIFF
--- a/Examples/Package.resolved
+++ b/Examples/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "7e9a15cf2d13e7366baf6cf1c43f6e78a133143e038e6562e747368077db4710",
+  "pins" : [
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms",
+      "state" : {
+        "revision" : "042e1c4d9d19748c9c228f8d4ebc97bb1e339b0b",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
+        "version" : "1.2.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -1,7 +1,39 @@
+// swift-tools-version: 6.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
 import PackageDescription
 
-let pacakge = Package(
+let package = Package(
     name: "Examples",
-    products: [],
-    targets: []
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14),
+        .watchOS(.v10),
+        .macCatalyst(.v15),
+        .tvOS(.v17),
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "Examples",
+            targets: ["Examples"]
+        ),
+    ],
+    dependencies: [
+        .package(name: "Oak", path: "../../Oak"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "Examples",
+            dependencies: [
+                "Oak"
+            ]
+        ),
+        .testTarget(
+            name: "ExamplesTests",
+            dependencies: ["Examples"]
+        ),
+    ]
 )

--- a/Examples/Sources/Examples/Counters.swift
+++ b/Examples/Sources/Examples/Counters.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+import Oak
+import Observation
+
+enum Counters: Transducer {
+    
+    enum State: Terminable {
+        case idle(value: Int)
+        case finished(value: Int)
+        var isTerminal: Bool {
+            switch self {
+            case .finished: return true
+            default: return false
+            }
+        }
+        var value: Int {
+            switch self {
+            case .idle(value: let value), .finished(value: let value):
+                return value
+            }
+        }
+    }
+    
+    enum Event {
+        case intentPlus
+        case intentMinus
+        case done
+    }
+    
+    static func update(_ state: inout State, event: Event) {
+        switch (state, event) {
+        case (.idle(let value), .intentPlus):
+            state = .idle(value: value + 1)
+        case (.idle(let value), .intentMinus):
+            state = .idle(value: value > 0 ? value - 1 : 0)
+        case (.idle(let value), .done):
+            state = .finished(value: value)
+        case (.finished, _):
+            break
+        }
+    }
+}
+
+struct CounterTransducerView: View {
+    var body: some View {
+        TransducerView(
+            of: Counters.self,
+            initialState: .idle(value: 0)
+        ) { state, input in
+            VStack(spacing: 20) {
+                Text("Count: \(state.value)")
+                HStack {
+                    Button("➖") { try? input.send(.intentMinus) }
+                    Button("➕") { try? input.send(.intentPlus) }
+                }
+                Button("Done") { try? input.send(.done) }
+            }
+            .disabled(state.isTerminal)
+            .padding()
+        }
+    }
+}
+
+struct CounterModelView: View {
+    typealias CounterModel = ObservableTransducer<Counters>
+    @State var model = CounterModel(initialState: .idle(value: 0))
+    var body: some View {
+        VStack {
+            VStack(spacing: 20) {
+                Text("Count: \(model.state.value)")
+                HStack {
+                    Button("➖") { try? model.proxy.send(.intentMinus) }
+                    Button("➕") { try? model.proxy.send(.intentPlus) }
+                }
+                Button("Done") { try? model.proxy.send(.done) }
+            }
+            .disabled(model.state.isTerminal)
+            .padding()
+        }
+    }
+}
+
+#Preview {
+    CounterTransducerView()
+}
+
+#Preview {
+    CounterModelView()
+}

--- a/Examples/Tests/ExamplesTests/ExamplesTests.swift
+++ b/Examples/Tests/ExamplesTests/ExamplesTests.swift
@@ -1,0 +1,6 @@
+import Testing
+@testable import Examples
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A type-safe, asynchronous finite state machine implementation for Swift, with po
 
 OAK provides a robust implementation of finite state machines (FSM), also known as finite state transducers (FST) for Swift applications. It enables you to model complex state transitions and side effects in a type-safe, testable, and maintainable way.
 
+
 ```swift
 // Simple, non-terminating counter state machine with async effects
 enum CounterTransducer: EffectTransducer {    
@@ -142,7 +143,6 @@ TransducerView(
 
 This supports a **"View only architecture"** where traditional artifacts like Model, ViewModel, Router, and Interactor are consolidated and implemented directly as SwiftUI views.
 
-## Installation
 
 ### Swift Package Manager
 
@@ -153,6 +153,21 @@ dependencies: [
 ```
 
 ## Quick Start
+
+### Install via Swift Package Manager
+In Xcode, select **File → Add Packages…** and enter:
+```
+https://github.com/couchdeveloper/Oak.git
+```
+or in your `Package.swift`:
+```swift
+dependencies: [
+  .package(url: "https://github.com/couchdeveloper/Oak.git", from: "0.15.0"),
+],
+targets: [
+  .target(name: "MyApp", dependencies: ["Oak"]),
+]
+```
 
 OAK uses **transducers** - finite state machines that process events and produce outputs. Here's how to create one in just a few steps:
 

--- a/Sources/Oak/FSM/EffectTransducer.swift
+++ b/Sources/Oak/FSM/EffectTransducer.swift
@@ -118,6 +118,7 @@ extension EffectTransducer {
         if let initialOutputValue = initialOutputValueOrNil {
             try await output.send(initialOutputValue, isolated: systemActor)
         }
+        try Task.checkCancellation()
         if storage.value.isTerminal {
             if let initialOutputValue = initialOutputValueOrNil {
                 return initialOutputValue
@@ -158,6 +159,7 @@ extension EffectTransducer {
                     }
                     nextEvent = events.popLast()
                 }
+                try Task.checkCancellation()
                 if storage.value.isTerminal {
                     result = outputValue!
                     proxy.finish()
@@ -268,6 +270,7 @@ extension EffectTransducer {
                     }
                     nextEvent = events.popLast()
                 }
+                try Task.checkCancellation()
                 if storage.value.isTerminal {
                     proxy.finish()
                     break loop

--- a/Sources/Oak/FSM/Transducer.swift
+++ b/Sources/Oak/FSM/Transducer.swift
@@ -145,6 +145,7 @@ extension Transducer {
         if let initialOutputValue = initialOutputValueOrNil {
             try await output.send(initialOutputValue, isolated: systemActor)
         }
+        try Task.checkCancellation()
         if storage.value.isTerminal {
             if let initialOutputValue = initialOutputValueOrNil {
                 return initialOutputValue
@@ -157,6 +158,7 @@ extension Transducer {
             loop: for try await event in stream {
                 let outputValue = Self.update(&storage.value, event: event)
                 try await output.send(outputValue, isolated: systemActor)
+                try Task.checkCancellation()
                 if storage.value.isTerminal {
                     result = outputValue
                     proxy.finish()

--- a/Sources/Oak/FSM/TransducerActor.swift
+++ b/Sources/Oak/FSM/TransducerActor.swift
@@ -289,6 +289,54 @@ extension TransducerActor {
             content: content
         )
     }
+    
+    /// Initialises a _transducer actor_ that runs a transducer with an update function that has the
+    /// signature `(inout State, Event) -> Output`.
+    ///
+    /// - Note: The Oak library has implementations for a `SwiftUI View` (aka `TransducerView`)
+    /// and an `Observable` (aka `ObservableTransducer`) which conform to protocol
+    /// `TransducerActor` and thus are _transducer actors_.
+    ///
+    /// The transducer's life-time (i.e. its _identity_) is bound to the actor's life-time. If the actor will be
+    /// desroyed before the transducer reaches a terminal state, it will be forcibly terminated. If the
+    /// transducer reaches a terminal state before the actor will be destroyed, user interactions send to
+    /// the transducer will be ignored.
+    ///
+    /// - Parameters:
+    ///   - type: The type of the transducer.
+    ///   - initialState: The start state of the transducer.
+    ///   - proxy: A proxy which will be associated to the transducer, or `nil` in which case the
+    ///   actor creates one.
+    ///   - completion: A closure which will be called once when the transducer completed
+    ///   successfully returning the success value of the run function.
+    ///   - failure: A closure which will be called once when the transducer completed
+    ///   with a failure returning the failure value of the run function.
+    ///   - content: A closure which takes the current state and the input as parameters and
+    ///  returns a content. The content closure can be used to drive other components that
+    ///  provide an interface and controls.
+    ///
+    /// ## Examples
+    ///
+    /// ### Using a TransducerView
+    /// TODO
+    ///
+    public init(
+        of type: Transducer.Type = Transducer.self,
+        initialState: sending State,
+        proxy: Proxy? = nil,
+        completion: Completion? = nil,
+        content: @escaping (State, Input) -> Content
+    ) where Transducer: Oak.Transducer {
+        self.init(
+            of: type,
+            initialState: initialState,
+            proxy: proxy,
+            output: NoCallback(),
+            completion: completion,
+            content: content
+        )
+    }
+
 
 }
 
@@ -373,6 +421,58 @@ extension TransducerActor {
         )
     }
 
+    /// Initialises a _transducer actor_ that runs an effect transducer with an update function that has the
+    /// signature `(inout State, Event) -> (Self.Effect?, Output)`.
+    ///
+    /// - Note: The Oak library has implementations for a `SwiftUI View` (aka `TransducerView`)
+    /// and an `Observable` (aka `ObservableTransducer`) which conform to protocol
+    /// `TransducerActor` and thus are _transducer actors_.
+    ///
+    /// The transducer's life-time (i.e. its _identity_) is bound to the actor's life-time. If the actor will be
+    /// desroyed before the transducer reaches a terminal state, it will be forcibly terminated. If the
+    /// transducer reaches a terminal state before the actor will be destroyed, user interactions send to
+    /// the transducer will be ignored.
+    ///
+    /// - Parameters:
+    ///   - type: The type of the transducer.
+    ///   - initialState: The start state of the transducer.
+    ///   - proxy: A proxy which will be associated to the transducer, or `nil` in which case the view
+    ///   creates one.
+    ///   - env: An environment value. The environment value will be passed as an argument to an
+    ///   `Effect`s' `invoke` function.
+    ///   - completion: A closure which will be called once when the transducer completed
+    ///   successfully returning the success value of the run function.
+    ///   - failure: A closure which will be called once when the transducer completed
+    ///   with a failure returning the failure value of the run function.
+    ///   - content: A closure which takes the current state and the input as parameters and
+    ///  returns a content. The content closure can be used to drive other components that
+    ///  provide an interface and controls.
+    ///
+    /// ## Examples
+    ///
+    /// ### Using a TransducerView
+    /// TODO
+    ///
+    public init(
+        of type: Transducer.Type = Transducer.self,
+        initialState: State,
+        proxy: Proxy? = nil,
+        env: Transducer.Env,
+        completion: Completion? = nil,
+        content: @escaping (State, Input) -> Content
+    ) where Transducer: Oak.EffectTransducer, Transducer.TransducerOutput == (Transducer.Effect?, Output) {
+        self.init(
+            of: type,
+            initialState: initialState,
+            proxy: proxy,
+            env: env,
+            output: NoCallback(),
+            completion: completion,
+            content: content
+        )
+    }
+
+    
     /// Initialises a _transducer actor_ that runs an effect transducer with an update function that has the
     /// signature `(inout State, Event) -> Self.Effect?`.
     ///
@@ -538,6 +638,48 @@ extension TransducerActor where Content == Never {
             content: { _, _ in fatalError("No content") }
         )
     }
+    
+    /// Initialises a _transducer actor_ that runs a transducer with an update function that has the
+    /// signature `(inout State, Event) -> Output`.
+    ///
+    /// - Note: The Oak library has implementations for a `SwiftUI View` (aka `TransducerView`)
+    /// and an `Observable` (aka `ObservableTransducer`) which conform to protocol
+    /// `TransducerActor` and thus are _transducer actors_.
+    ///
+    /// The transducer's life-time (i.e. its _identity_) is bound to the actor's life-time. If the actor will be
+    /// desroyed before the transducer reaches a terminal state, it will be forcibly terminated. If the
+    /// transducer reaches a terminal state before the actor will be destroyed, user interactions send to
+    /// the transducer will be ignored.
+    ///
+    /// - Parameters:
+    ///   - type: The type of the transducer.
+    ///   - initialState: The start state of the transducer.
+    ///   - proxy: A proxy which will be associated to the transducer, or `nil` in which case the view
+    ///   creates one.
+    ///   - completion: A closure which will be called once when the transducer completed
+    ///   successfully returning the success value of the run function.
+    ///   - failure: A closure which will be called once when the transducer completed
+    ///   with a failure returning the failure value of the run function.
+    ///
+    /// ## Examples
+    ///
+    /// ### Using an ObservableTransducer
+    /// TODO
+    ///
+    public init(
+        of type: Transducer.Type = Transducer.self,
+        initialState: sending State,
+        proxy: Proxy? = nil,
+        completion: Completion? = nil,
+    ) where Transducer: Oak.Transducer {
+        self.init(
+            initialState: initialState,
+            proxy: proxy,
+            output: NoCallback(),
+            completion: completion,
+            content: { _, _ in fatalError("No content") }
+        )
+    }
 
 }
 
@@ -592,6 +734,52 @@ extension TransducerActor where Content == Never {
         )
     }
 
+    /// Initialises a _transducer actor_ that runs an effect transducer with an update function that has the
+    /// signature `(inout State, Event) -> (Self.Effect?, Output)`.
+    ///
+    /// - Note: The Oak library has implementations for a `SwiftUI View` (aka `TransducerView`)
+    /// and an `Observable` (aka `ObservableTransducer`) which conform to protocol
+    /// `TransducerActor` and thus are _transducer actors_.
+    ///
+    /// The transducer's life-time (i.e. its _identity_) is bound to the actor's life-time. If the actor will be
+    /// desroyed before the transducer reaches a terminal state, it will be forcibly terminated. If the
+    /// transducer reaches a terminal state before the actor will be destroyed, user interactions send to
+    /// the transducer will be ignored.
+    ///
+    /// - Parameters:
+    ///   - type: The type of the transducer.
+    ///   - initialState: The start state of the transducer.
+    ///   - proxy: A proxy which will be associated to the transducer, or `nil` in which case the view
+    ///   creates one.
+    ///   - env: An environment value. The environment value will be passed as an argument to an
+    ///   `Effect`s' `invoke` function.
+    ///   - completion: A closure which will be called once when the transducer completed
+    ///   successfully returning the success value of the run function.
+    ///   - failure: A closure which will be called once when the transducer completed
+    ///   with a failure returning the failure value of the run function.
+    ///
+    /// ## Examples
+    ///
+    /// ### Using an ObservableTransducer
+    /// TODO
+    ///
+    public init(
+        of type: Transducer.Type = Transducer.self,
+        initialState: State,
+        proxy: Proxy? = nil,
+        env: Transducer.Env,
+        completion: Completion? = nil,
+    ) where Transducer: Oak.EffectTransducer, Transducer.TransducerOutput == (Transducer.Effect?, Output) {
+        self.init(
+            initialState: initialState,
+            proxy: proxy,
+            env: env,
+            output: NoCallback(),
+            completion: completion,
+            content: { _, _ in fatalError("No content") }
+        )
+    }
+    
     /// Initialises a _transducer actor_ that runs an effect transducer with an update function that has the
     /// signature `(inout State, Event) -> Self.Effect?`.
     ///

--- a/Sources/Oak/SwiftUI/SwiftUI.TransducerActor.swift
+++ b/Sources/Oak/SwiftUI/SwiftUI.TransducerActor.swift
@@ -144,7 +144,53 @@ extension TransducerActor where Content: View {
         )
     }
 
-}
+    /// Initialises a _transducer actor_ that runs a transducer with an update function that has the
+    /// signature `(inout State, Event) -> Output`.
+    ///
+    /// - Note: The Oak library has implementations for a `SwiftUI View` (aka `TransducerView`)
+    /// and an `Observable` (aka `ObservableTransducer`) which conform to protocol
+    /// `TransducerActor` and thus are _transducer actors_.
+    ///
+    /// The transducer's life-time (i.e. its _identity_) is bound to the actor's life-time. If the actor will be
+    /// desroyed before the transducer reaches a terminal state, it will be forcibly terminated. If the
+    /// transducer reaches a terminal state before the actor will be destroyed, user interactions send to
+    /// the transducer will be ignored.
+    ///
+    /// - Parameters:
+    ///   - type: The type of the transducer.
+    ///   - initialState: The start state of the transducer.
+    ///   - proxy: A proxy which will be associated to the transducer, or `nil` in which case the
+    ///   actor creates one.
+    ///   - completion: A closure which will be called once when the transducer completed
+    ///   successfully returning the success value of the run function.
+    ///   - failure: A closure which will be called once when the transducer completed
+    ///   with a failure returning the failure value of the run function.
+    ///   - content: A closure which takes the current state and the input as parameters and
+    ///  returns a content. The content closure can be used to drive other components that
+    ///  provide an interface and controls.
+    ///
+    /// ## Examples
+    ///
+    /// ### Using a TransducerView
+    /// TODO
+    ///
+    public init(
+        of type: Transducer.Type = Transducer.self,
+        initialState: sending State,
+        proxy: Proxy? = nil,
+        completion: Completion? = nil,
+        @ViewBuilder viewContent: @escaping (State, Input) -> Content
+    ) where Transducer: Oak.Transducer {
+        self.init(
+            of: type,
+            initialState: initialState,
+            proxy: proxy,
+            completion: completion,
+            content: viewContent
+        )
+    }
+
+    }
 
 extension TransducerActor where Content: View {
 
@@ -197,6 +243,56 @@ extension TransducerActor where Content: View {
             proxy: proxy,
             env: env,
             output: output,
+            completion: completion,
+            content: viewContent
+        )
+    }
+    
+    /// Initialises a _transducer actor_ that runs a transducer with an update function that has the
+    /// signature `(inout State, Event) -> (Self.Effect?, Output)`.
+    ///
+    /// - Note: The Oak library has implementations for a `SwiftUI View` (aka `TransducerView`)
+    /// and an `Observable` (aka `ObservableTransducer`) which conform to protocol
+    /// `TransducerActor` and thus are _transducer actors_.
+    ///
+    /// The transducer's life-time (i.e. its _identity_) is bound to the actor's life-time. If the actor will be
+    /// desroyed before the transducer reaches a terminal state, it will be forcibly terminated. If the
+    /// transducer reaches a terminal state before the actor will be destroyed, user interactions send to
+    /// the transducer will be ignored.
+    ///
+    /// - Parameters:
+    ///   - type: The type of the transducer.
+    ///   - initialState: The start state of the transducer.
+    ///   - proxy: A proxy which will be associated to the transducer, or `nil` in which case the view
+    ///   creates one.
+    ///   - env: An environment value. The environment value will be passed as an argument to an
+    ///   `Effect`s' `invoke` function.
+    ///   - completion: A closure which will be called once when the transducer completed
+    ///   successfully returning the success value of the run function.
+    ///   - failure: A closure which will be called once when the transducer completed
+    ///   with a failure returning the failure value of the run function.
+    ///   - content: A closure which takes the current state and the input as parameters and
+    ///  returns a content. The content closure can be used to drive other components that
+    ///  provide an interface and controls.
+    ///
+    /// ## Examples
+    ///
+    /// ### Using a TransducerView
+    /// TODO
+    ///
+    public init(
+        of type: Transducer.Type = Transducer.self,
+        initialState: State,
+        proxy: Proxy? = nil,
+        env: Transducer.Env,
+        completion: Completion? = nil,
+        @ViewBuilder viewContent: @escaping (State, Input) -> Content
+    ) where Transducer: Oak.EffectTransducer, Transducer.TransducerOutput == (Transducer.Effect?, Output) {
+        self.init(
+            of: type,
+            initialState: initialState,
+            proxy: proxy,
+            env: env,
             completion: completion,
             content: viewContent
         )


### PR DESCRIPTION
fix(fsm): more eager Task cancellation 

    - TransducerActor now checks Task.isCancelled more frequently to avoid accessing storage after deinit
    - Fixed the failing unit test that surfaced after tightening cancellation logic
    - Added a working example in Examples/ showcasing TransducerView usage