### PR TITLE
Add Swift-DocC support and fix documentation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+
+# Generated Documentation
+/docs/
+/generated-docs/
+*.doccarchive

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0b508376249d52fd1ded2bd74f8c8a23962d07c99999ce0f27bb17c0b3862bd0",
+  "originHash" : "8ad3534347bd9c7b122a1966dda75227a74b3e692b2fd7aee868f4337358f829",
   "pins" : [
     {
       "identity" : "swift-async-algorithms",
@@ -17,6 +17,24 @@
       "state" : {
         "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
         "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
+        "version" : "1.4.5"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -1,0 +1,77 @@
+# Oak Documentation Scripts
+
+This directory contains utility scripts for working with Oak framework documentation.
+
+## Scripts
+
+### `previewDocs.sh`
+Generates and previews Oak framework documentation locally using Swift-DocC.
+
+**Usage:**
+```bash
+./Scripts/previewDocs.sh
+
+# For VS Code users (if Safari blocks HTTP):
+./Scripts/previewDocs.sh --vscode
+```
+
+**Features:**
+- Automatically builds the project and generates documentation
+- Starts a local preview server on port 8081
+- Smart browser detection: tries Chrome/Firefox first, falls back to default
+- Opens the documentation in your browser at http://localhost:8081/documentation/oak
+- `--vscode` flag for VS Code Simple Browser compatibility
+- Handles port conflicts automatically
+- Colorized output for better readability
+
+**Requirements:**
+- Swift 6.0+ with Swift-DocC plugin
+- macOS with `open` command available
+- For best experience: Chrome, Firefox, or Edge (Safari may require HTTP localhost permission)
+
+### `generateDocs.sh`
+Generates static documentation files for deployment.
+
+**Usage:**
+```bash
+./Scripts/generateDocs.sh
+```
+
+**Features:**
+- Generates static documentation optimized for web hosting
+- Outputs to `generated-docs/` directory
+- Includes instructions for local serving
+- Suitable for CI/CD and deployment workflows
+
+**Output:**
+- Static HTML files in `generated-docs/`
+- Access via http://localhost:8080/documentation/oak when served locally
+- Ready for deployment to GitHub Pages or other static hosting
+
+## Notes
+
+- Both scripts must be run from the Oak project root directory
+- The scripts automatically handle the `--disable-sandbox` flag required by Swift-DocC
+- Generated documentation includes all public APIs with documentation comments
+- For the best documentation experience, add DocC comments to your Swift code
+
+## Troubleshooting
+
+**Port 8081 already in use:**
+The scripts automatically detect and resolve port conflicts.
+
+**Permission denied:**
+Make sure the scripts are executable:
+```bash
+chmod +x Scripts/*.sh
+```
+
+**Swift-DocC not available:**
+Ensure you have the Swift-DocC plugin dependency in your `Package.swift`.
+
+**Safari HTTP localhost issues:**
+Safari may block HTTP connections to localhost. Solutions:
+1. The script automatically tries Chrome/Firefox first if available
+2. In Safari: Develop menu → Disable Local File Restrictions
+3. Or manually open: http://localhost:8081/documentation/oak
+4. Or install Chrome/Firefox for better localhost development support

--- a/Scripts/generateDocs.sh
+++ b/Scripts/generateDocs.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# generateDocs.sh - Generate static Oak framework documentation
+# This script generates static documentation using Swift-DocC for deployment
+
+set -e  # Exit on any error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Script directory and project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+echo -e "${BLUE}📚 Oak Documentation Generator${NC}"
+echo -e "${BLUE}==============================${NC}"
+
+# Check if we're in the right directory
+if [ ! -f "$PROJECT_ROOT/Package.swift" ]; then
+    echo -e "${RED}❌ Error: Package.swift not found. Please run this script from the Oak project root.${NC}"
+    exit 1
+fi
+
+# Change to project root
+cd "$PROJECT_ROOT"
+
+# Check for running Swift processes and stop them
+echo -e "${YELLOW}🔍 Checking for running Swift Package Manager processes...${NC}"
+SPM_PIDS=$(pgrep -f "swift package" 2>/dev/null || true)
+if [ -n "$SPM_PIDS" ]; then
+    echo -e "${YELLOW}⚠️  Found running Swift Package Manager processes. Stopping them...${NC}"
+    echo "$SPM_PIDS" | xargs kill -TERM 2>/dev/null || true
+    sleep 2
+    # Force kill if still running
+    SPM_PIDS=$(pgrep -f "swift package" 2>/dev/null || true)
+    if [ -n "$SPM_PIDS" ]; then
+        echo -e "${YELLOW}⚠️  Force stopping Swift Package Manager processes...${NC}"
+        echo "$SPM_PIDS" | xargs kill -9 2>/dev/null || true
+        sleep 1
+    fi
+fi
+
+# Also check for any processes using the .build directory
+if [ -d ".build" ]; then
+    BUILD_PIDS=$(lsof +D .build 2>/dev/null | awk 'NR>1 {print $2}' | sort -u 2>/dev/null || true)
+    if [ -n "$BUILD_PIDS" ]; then
+        echo -e "${YELLOW}⚠️  Found processes using .build directory. Stopping them...${NC}"
+        echo "$BUILD_PIDS" | xargs kill -TERM 2>/dev/null || true
+        sleep 2
+    fi
+fi
+
+# Clean up previous documentation
+if [ -d "generated-docs" ]; then
+    echo -e "${YELLOW}🧹 Cleaning up previous documentation...${NC}"
+    rm -rf generated-docs
+fi
+
+echo -e "${YELLOW}📚 Generating static documentation...${NC}"
+
+# First, try to generate documentation without static hosting to see if basic generation works
+echo -e "${BLUE}ℹ️  Attempting basic documentation generation first...${NC}"
+
+# Create output directory
+mkdir -p ./generated-docs
+
+# Try basic documentation generation first
+if swift package --disable-sandbox generate-documentation --target Oak; then
+    echo -e "${GREEN}✅ Basic documentation generation successful!${NC}"
+    
+    # Now try with static hosting transformation
+    echo -e "${BLUE}ℹ️  Converting to static hosting format...${NC}"
+    
+    # Generate static documentation
+    if swift package --disable-sandbox generate-documentation \
+        --target Oak \
+        --disable-indexing \
+        --transform-for-static-hosting \
+        --output-path ./generated-docs; then
+        
+        echo -e "${GREEN}✅ Documentation generated successfully!${NC}"
+        echo -e "${BLUE}📁 Output location: $(pwd)/generated-docs${NC}"
+        echo -e "${BLUE}🌐 To serve locally: cd generated-docs && python3 -m http.server 8080${NC}"
+        echo -e "${BLUE}   Then open: http://localhost:8080/documentation/oak${NC}"
+    else
+        echo -e "${YELLOW}⚠️  Static hosting transformation failed, but basic docs were generated.${NC}"
+        echo -e "${BLUE}ℹ️  You can find the documentation in: .build/plugins/Swift-DocC/outputs/Oak.doccarchive${NC}"
+        echo -e "${BLUE}ℹ️  To view: open .build/plugins/Swift-DocC/outputs/Oak.doccarchive${NC}"
+    fi
+else
+    echo -e "${RED}❌ Documentation generation failed.${NC}"
+    echo -e "${YELLOW}💡 This might be because:${NC}"
+    echo -e "${YELLOW}   1. No .docc catalog exists in the project${NC}"
+    echo -e "${YELLOW}   2. No documentation comments are present${NC}"
+    echo -e "${YELLOW}   3. The target name might be incorrect${NC}"
+    echo ""
+    echo -e "${BLUE}ℹ️  Try adding some documentation comments to your Swift files first.${NC}"
+    echo -e "${BLUE}ℹ️  Example: /// This is a documentation comment${NC}"
+    exit 1
+fi

--- a/Scripts/previewDocs.sh
+++ b/Scripts/previewDocs.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# previewDocs.sh - Generate and preview Oak framework documentation
+# This script generates documentation using Swift-DocC and opens it in the default browser
+
+set -e  # Exit on any error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Script directory and project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+echo -e "${BLUE}🚀 Oak Documentation Preview${NC}"
+echo -e "${BLUE}=============================${NC}"
+
+# Check for optional --vscode flag to use VS Code's simple browser
+USE_VSCODE_BROWSER=false
+if [[ "$1" == "--vscode" ]]; then
+    USE_VSCODE_BROWSER=true
+    echo -e "${BLUE}ℹ️  Using VS Code Simple Browser mode${NC}"
+fi
+
+# Check if we're in the right directory
+if [ ! -f "$PROJECT_ROOT/Package.swift" ]; then
+    echo -e "${RED}❌ Error: Package.swift not found. Please run this script from the Oak project root.${NC}"
+    exit 1
+fi
+
+# Change to project root
+cd "$PROJECT_ROOT"
+
+# Check for running Swift processes and stop them
+echo -e "${YELLOW}🔍 Checking for running Swift Package Manager processes...${NC}"
+SPM_PIDS=$(pgrep -f "swift package" 2>/dev/null || true)
+if [ -n "$SPM_PIDS" ]; then
+    echo -e "${YELLOW}⚠️  Found running Swift Package Manager processes. Stopping them...${NC}"
+    echo "$SPM_PIDS" | xargs kill -TERM 2>/dev/null || true
+    sleep 2
+    # Force kill if still running
+    SPM_PIDS=$(pgrep -f "swift package" 2>/dev/null || true)
+    if [ -n "$SPM_PIDS" ]; then
+        echo -e "${YELLOW}⚠️  Force stopping Swift Package Manager processes...${NC}"
+        echo "$SPM_PIDS" | xargs kill -9 2>/dev/null || true
+        sleep 1
+    fi
+fi
+
+echo -e "${YELLOW}📚 Generating documentation...${NC}"
+
+# Generate documentation with preview server
+echo -e "${BLUE}ℹ️  Starting documentation preview server...${NC}"
+echo -e "${BLUE}   This will build the project and start a local server.${NC}"
+echo -e "${BLUE}   Press Ctrl+C to stop the server when done.${NC}"
+echo ""
+
+# Check if port 8081 is already in use
+if lsof -Pi :8081 -sTCP:LISTEN -t >/dev/null 2>&1; then
+    echo -e "${YELLOW}⚠️  Port 8081 is already in use. Trying to stop existing process...${NC}"
+    lsof -ti:8081 | xargs kill -9 2>/dev/null || true
+    sleep 2
+fi
+
+# Start the documentation preview server
+echo -e "${GREEN}🔧 Starting Swift-DocC preview server...${NC}"
+
+# Function to open browser after server starts
+open_browser() {
+    sleep 3  # Wait for server to start
+    echo -e "${GREEN}🌐 Opening documentation in browser...${NC}"
+    
+    if [[ "$USE_VSCODE_BROWSER" == "true" ]]; then
+        echo -e "${BLUE}ℹ️  Opening in VS Code Simple Browser...${NC}"
+        echo -e "${BLUE}   Note: Copy this URL to VS Code's Simple Browser: http://localhost:8081/documentation/oak${NC}"
+        return
+    fi
+    
+    # Try to open in developer-friendly browsers first, then fall back to default
+    if command -v "/Applications/Firefox.app/Contents/MacOS/firefox" >/dev/null 2>&1; then
+        echo -e "${BLUE}ℹ️  Opening in Firefox (HTTP-friendly)...${NC}"
+        open -a "Firefox" "http://localhost:8081/documentation/oak"
+    elif command -v "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" >/dev/null 2>&1; then
+        echo -e "${BLUE}ℹ️  Opening in Google Chrome (HTTP-friendly)...${NC}"
+        open -a "Google Chrome" "http://localhost:8081/documentation/oak"
+    elif command -v "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge" >/dev/null 2>&1; then
+        echo -e "${BLUE}ℹ️  Opening in Microsoft Edge (HTTP-friendly)...${NC}"
+        open -a "Microsoft Edge" "http://localhost:8081/documentation/oak"
+    else
+        echo -e "${YELLOW}⚠️  Opening in default browser...${NC}"
+        echo -e "${YELLOW}   If Safari shows security warnings for HTTP, try:${NC}"
+        echo -e "${YELLOW}   1. Run: ./Scripts/previewDocs.sh --vscode (for VS Code Simple Browser)${NC}"
+        echo -e "${YELLOW}   2. Allow HTTP for localhost in Safari settings${NC}"
+        echo -e "${YELLOW}   3. Or manually open: http://localhost:8081/documentation/oak${NC}"
+        echo -e "${YELLOW}   4. Or install Chrome/Firefox for better HTTP localhost support${NC}"
+        open "http://localhost:8081/documentation/oak"
+    fi
+}
+
+# Start browser opener in background
+open_browser &
+
+# Start the documentation preview server
+# The --disable-sandbox flag is required for network access
+swift package --disable-sandbox plugin preview-documentation --target Oak --port 8081
+
+echo -e "${GREEN}✅ Documentation preview completed.${NC}"
+if [[ "$USE_VSCODE_BROWSER" == "true" ]]; then
+    echo -e "${BLUE}💡 To view in VS Code: Open Simple Browser and navigate to:${NC}"
+    echo -e "${BLUE}   http://localhost:8081/documentation/oak${NC}"
+fi

--- a/Sources/Oak/FSM/EffectTransducer.swift
+++ b/Sources/Oak/FSM/EffectTransducer.swift
@@ -470,8 +470,6 @@ extension EffectTransducer {
     ///   when running the transducer. The default value `#isolation` uses the 
     ///   current actor context.
     /// 
-    /// - Returns: The final output produced by the transducer when the state
-    ///   becomes terminal.
     /// - Throws: An error if the transducer cannot execute its transition and
     ///   output function as expected. For example, if the initial state is
     ///   terminal, or if no output is produced, or when events could not be

--- a/Sources/Oak/FSM/Subject.swift
+++ b/Sources/Oak/FSM/Subject.swift
@@ -59,6 +59,7 @@ public protocol Subject<Value> {
     /// is successfully delivered to the destination.
     ///
     /// - Parameter value: The value which should be send to the destination.
+    /// - Parameter isolated: The actor isolation context for the send operation.
     /// - Throws: When the value could not be delivered to the destination, it throws an error.
     func send(_ value: sending Value, isolated: isolated any Actor) async throws
 }

--- a/Sources/Oak/FSM/TransducerActor.swift
+++ b/Sources/Oak/FSM/TransducerActor.swift
@@ -3,7 +3,15 @@
 /// ## Overview
 ///
 /// A `TransducerActor` provides the state for the transducer and the isolation context in which it runs.
-/// While transducer functions can be called directly without an actor (in which case they "strictly encapsulate" 
+///   - output: A type conforming to `Subject<o>` where the transducer sends the
+///   output it produces.
+///   - completion: A completion handler which will be called once when the transducer
+///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
+///   - content: A closure which takes the current state and the input as parameters and
+///  returns a content. The content closure can be used to drive other components that
+///  provide an interface and controls.
+///
+/// ## Examplesducer functions can be called directly without an actor (in which case they "strictly encapsulate" 
 /// the state), the main purpose of having a `TransducerActor` is to provide _observable_ state that can be 
 /// integrated with UI frameworks and reactive systems.
 ///
@@ -90,6 +98,9 @@ public protocol TransducerActor<Transducer> {
     /// - Parameters:
     ///   - initialState: The start state of the transducer.
     ///   - proxy: A proxy which will be associated to the transducer.
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a `Result` that contains either the successful output value or
+    ///   an error if the transducer failed.
     ///   - runTransducer: A closure which will be immediately called when the actor will be initialised.
     ///   It starts the transducer which runs in a Swift Task.
     ///   - content: A closure which takes the current state and the input as parameters and
@@ -138,7 +149,8 @@ extension TransducerActor {
     ///   - proxy: A proxy which will be associated to the transducer, or `nil` in which case the
     ///   actor creates one.
     ///   - completion: An optional completion handler which will be called once when the transducer 
-    ///   completes, either successfully with the final output value or with a failure error.
+    ///   finishes, providing a `Result` that contains either the successful output value or
+    ///   an error if the transducer failed.
     ///   - content: A closure which takes the current state and the input as parameters and
     ///   returns a content. The content closure can be used to drive other components that
     ///   provide an interface and controls.
@@ -243,10 +255,8 @@ extension TransducerActor {
     ///   actor creates one.
     ///   - output: A type conforming to `Subject<Output>` where the transducer sends the
     ///   output it produces.
-    ///   - completion: A closure which will be called once when the transducer completed
-    ///   successfully returning the success value of the run function.
-    ///   - failure: A closure which will be called once when the transducer completed
-    ///   with a failure returning the failure value of the run function.
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
     ///   - content: A closure which takes the current state and the input as parameters and
     ///  returns a content. The content closure can be used to drive other components that
     ///  provide an interface and controls.
@@ -307,10 +317,8 @@ extension TransducerActor {
     ///   - initialState: The start state of the transducer.
     ///   - proxy: A proxy which will be associated to the transducer, or `nil` in which case the
     ///   actor creates one.
-    ///   - completion: A closure which will be called once when the transducer completed
-    ///   successfully returning the success value of the run function.
-    ///   - failure: A closure which will be called once when the transducer completed
-    ///   with a failure returning the failure value of the run function.
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
     ///   - content: A closure which takes the current state and the input as parameters and
     ///  returns a content. The content closure can be used to drive other components that
     ///  provide an interface and controls.
@@ -363,10 +371,8 @@ extension TransducerActor {
     ///   `Effect`s' `invoke` function.
     ///   - output: A type conforming to `Subject<Output>` where the transducer sends the
     ///   output it produces.
-    ///   - completion: A closure which will be called once when the transducer completed
-    ///   successfully returning the success value of the run function.
-    ///   - failure: A closure which will be called once when the transducer completed
-    ///   with a failure returning the failure value of the run function.
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
     ///   - content: A closure which takes the current state and the input as parameters and
     ///  returns a content. The content closure can be used to drive other components that
     ///  provide an interface and controls.
@@ -440,10 +446,8 @@ extension TransducerActor {
     ///   creates one.
     ///   - env: An environment value. The environment value will be passed as an argument to an
     ///   `Effect`s' `invoke` function.
-    ///   - completion: A closure which will be called once when the transducer completed
-    ///   successfully returning the success value of the run function.
-    ///   - failure: A closure which will be called once when the transducer completed
-    ///   with a failure returning the failure value of the run function.
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
     ///   - content: A closure which takes the current state and the input as parameters and
     ///  returns a content. The content closure can be used to drive other components that
     ///  provide an interface and controls.
@@ -492,10 +496,8 @@ extension TransducerActor {
     ///   creates one.
     ///   - env: An environment value. The environment value will be passed as an argument to an
     ///   `Effect`s' `invoke` function.
-    ///   - completion: A closure which will be called once when the transducer completed
-    ///   successfully returning the success value of the run function.
-    ///   - failure: A closure which will be called once when the transducer completed
-    ///   with a failure returning the failure value of the run function.
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
     ///   - content: A closure which takes the current state and the input as parameters and
     ///  returns a content. The content closure can be used to drive other components that
     ///  provide an interface and controls.
@@ -565,15 +567,12 @@ extension TransducerActor where Content == Never {
     /// the transducer will be ignored.
     ///
     /// - Parameters:
-    ///   - isolated: The isolation from the caller.
     ///   - type: The type of the transducer.
     ///   - initialState: The start state of the transducer.
     ///   - proxy: A proxy which will be associated to the transducer, or `nil` in which case the view
     ///   creates one.
-    ///   - completion: A closure which will be called once when the transducer completed
-    ///   successfully returning the success value of the run function.
-    ///   - failure: A closure which will be called once when the transducer completed
-    ///   with a failure returning the failure value of the run function.
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
     ///
     /// ## Examples
     ///
@@ -613,10 +612,8 @@ extension TransducerActor where Content == Never {
     ///   creates one.
     ///   - output: A type conforming to `Subject<Output>` where the transducer sends the
     ///   output it produces.
-    ///   - completion: A closure which will be called once when the transducer completed
-    ///   successfully returning the success value of the run function.
-    ///   - failure: A closure which will be called once when the transducer completed
-    ///   with a failure returning the failure value of the run function.
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
     ///
     /// ## Examples
     ///
@@ -656,10 +653,8 @@ extension TransducerActor where Content == Never {
     ///   - initialState: The start state of the transducer.
     ///   - proxy: A proxy which will be associated to the transducer, or `nil` in which case the view
     ///   creates one.
-    ///   - completion: A closure which will be called once when the transducer completed
-    ///   successfully returning the success value of the run function.
-    ///   - failure: A closure which will be called once when the transducer completed
-    ///   with a failure returning the failure value of the run function.
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
     ///
     /// ## Examples
     ///
@@ -706,10 +701,8 @@ extension TransducerActor where Content == Never {
     ///   `Effect`s' `invoke` function.
     ///   - output: A type conforming to `Subject<Output>` where the transducer sends the
     ///   output it produces.
-    ///   - completion: A closure which will be called once when the transducer completed
-    ///   successfully returning the success value of the run function.
-    ///   - failure: A closure which will be called once when the transducer completed
-    ///   with a failure returning the failure value of the run function.
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
     ///
     /// ## Examples
     ///
@@ -753,10 +746,8 @@ extension TransducerActor where Content == Never {
     ///   creates one.
     ///   - env: An environment value. The environment value will be passed as an argument to an
     ///   `Effect`s' `invoke` function.
-    ///   - completion: A closure which will be called once when the transducer completed
-    ///   successfully returning the success value of the run function.
-    ///   - failure: A closure which will be called once when the transducer completed
-    ///   with a failure returning the failure value of the run function.
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
     ///
     /// ## Examples
     ///
@@ -799,10 +790,8 @@ extension TransducerActor where Content == Never {
     ///   creates one.
     ///   - env: An environment value. The environment value will be passed as an argument to an
     ///   `Effect`s' `invoke` function.
-    ///   - completion: A closure which will be called once when the transducer completed
-    ///   successfully returning the success value of the run function.
-    ///   - failure: A closure which will be called once when the transducer completed
-    ///   with a failure returning the failure value of the run function.
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
     ///
     /// ## Examples
     ///

--- a/Sources/Oak/SwiftUI/ObservableTransducer.swift
+++ b/Sources/Oak/SwiftUI/ObservableTransducer.swift
@@ -52,12 +52,15 @@ public final class ObservableTransducer<Transducer>: @MainActor TransducerActor 
     /// overloads.
     ///
     /// - Parameters:
-    ///   - isolated: The isolation from the caller.
     ///   - initialState: The start state of the transducer.
     ///   - proxy: A proxy which will be associated to the transducer, or `nil` in which case the view
     ///   creates one.
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a `Result` that contains either the successful output value or
+    ///   an error if the transducer failed.
     ///   - runTransducer: A closure which will be immediately called when the actor will be initialised.
     ///   It starts the transducer which runs in a Swift Task.
+    ///   - content: A closure for creating content based on state and input.
     ///
     public init(
         initialState: State,

--- a/Sources/Oak/SwiftUI/SwiftUI.Transducer.swift
+++ b/Sources/Oak/SwiftUI/SwiftUI.Transducer.swift
@@ -91,7 +91,6 @@ extension Transducer {
     ///   SwiftUI view.
     ///   - proxy: The proxy, that will be associated to the transducer as its agent.
     ///   - isolated: The actor where the `update` function will run on and where the state
-    /// - Returns: The output, that has been generated when the transducer reaches a terminal state.
     /// - Warning: The backing store for the state variable must not be mutated by the caller or must not be used with any other transducer.
     /// - Throws: Throws an error indicating the reason, for example, when the Swift Task, where the
     /// transducer is running on, has been cancelled, or when it has been forcibly terminated, and thus could

--- a/Sources/Oak/SwiftUI/SwiftUI.TransducerActor.swift
+++ b/Sources/Oak/SwiftUI/SwiftUI.TransducerActor.swift
@@ -17,16 +17,12 @@ extension TransducerActor where Content: View {
     ///
     /// - Parameters:
     ///   - type: The type of the transducer.
-    ///   - isolated: The isolation from the caller.
-    ///   - type: The type of the transducer.
     ///   - initialState: The start state of the transducer.
     ///   - proxy: A proxy which will be associated to the transducer, or `nil` in which case the view
     ///   creates one.
-    ///   - completion: A closure which will be called once when the transducer completed
-    ///   successfully returning the success value of the run function.
-    ///   - failure: A closure which will be called once when the transducer completed
-    ///   with a failure returning the failure value of the run function.
-    ///   - content: A closure which takes the current state and the input as parameters and
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
+    ///   - viewContent: A closure which takes the current state and the input as parameters and
     ///  returns a content. The content closure can be used to drive other components that
     ///  provide an interface and controls.
     ///
@@ -113,11 +109,9 @@ extension TransducerActor where Content: View {
     ///   actor creates one.
     ///   - output: A type conforming to `Subject<Output>` where the transducer sends the
     ///   output it produces.
-    ///   - completion: A closure which will be called once when the transducer completed
-    ///   successfully returning the success value of the run function.
-    ///   - failure: A closure which will be called once when the transducer completed
-    ///   with a failure returning the failure value of the run function.
-    ///   - content: A closure which takes the current state and the input as parameters and
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
+    ///   - viewContent: A closure which takes the current state and the input as parameters and
     ///  returns a content. The content closure can be used to drive other components that
     ///  provide an interface and controls.
     ///
@@ -161,11 +155,9 @@ extension TransducerActor where Content: View {
     ///   - initialState: The start state of the transducer.
     ///   - proxy: A proxy which will be associated to the transducer, or `nil` in which case the
     ///   actor creates one.
-    ///   - completion: A closure which will be called once when the transducer completed
-    ///   successfully returning the success value of the run function.
-    ///   - failure: A closure which will be called once when the transducer completed
-    ///   with a failure returning the failure value of the run function.
-    ///   - content: A closure which takes the current state and the input as parameters and
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
+    ///   - viewContent: A closure which takes the current state and the input as parameters and
     ///  returns a content. The content closure can be used to drive other components that
     ///  provide an interface and controls.
     ///
@@ -215,11 +207,9 @@ extension TransducerActor where Content: View {
     ///   `Effect`s' `invoke` function.
     ///   - output: A type conforming to `Subject<Output>` where the transducer sends the
     ///   output it produces.
-    ///   - completion: A closure which will be called once when the transducer completed
-    ///   successfully returning the success value of the run function.
-    ///   - failure: A closure which will be called once when the transducer completed
-    ///   with a failure returning the failure value of the run function.
-    ///   - content: A closure which takes the current state and the input as parameters and
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
+    ///   - viewContent: A closure which takes the current state and the input as parameters and
     ///  returns a content. The content closure can be used to drive other components that
     ///  provide an interface and controls.
     ///
@@ -267,11 +257,9 @@ extension TransducerActor where Content: View {
     ///   creates one.
     ///   - env: An environment value. The environment value will be passed as an argument to an
     ///   `Effect`s' `invoke` function.
-    ///   - completion: A closure which will be called once when the transducer completed
-    ///   successfully returning the success value of the run function.
-    ///   - failure: A closure which will be called once when the transducer completed
-    ///   with a failure returning the failure value of the run function.
-    ///   - content: A closure which takes the current state and the input as parameters and
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
+    ///   - viewContent: A closure which takes the current state and the input as parameters and
     ///  returns a content. The content closure can be used to drive other components that
     ///  provide an interface and controls.
     ///
@@ -317,11 +305,9 @@ extension TransducerActor where Content: View {
     ///   creates one.
     ///   - env: An environment value. The environment value will be passed as an argument to an
     ///   `Effect`s' `invoke` function.
-    ///   - completion: A closure which will be called once when the transducer completed
-    ///   successfully returning the success value of the run function.
-    ///   - failure: A closure which will be called once when the transducer completed
-    ///   with a failure returning the failure value of the run function.
-    ///   - content: A closure which takes the current state and the input as parameters and
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a Result that contains either the successful output value or an error if the transducer failed.
+    ///   - viewContent: A closure which takes the current state and the input as parameters and
     ///  returns a content. The content closure can be used to drive other components that
     ///  provide an interface and controls.
     ///

--- a/Sources/Oak/SwiftUI/TransducerView.swift
+++ b/Sources/Oak/SwiftUI/TransducerView.swift
@@ -68,10 +68,12 @@ public struct TransducerView<Transducer, Content>: View, @MainActor TransducerAc
     /// overloads.
     ///
     /// - Parameters:
-    ///   - isolated: The isolation from the caller.
     ///   - initialState: The start state of the transducer.
     ///   - proxy: A proxy which will be associated to the transducer, or `nil` in which case the view
     ///   creates one.
+    ///   - completion: A completion handler which will be called once when the transducer
+    ///   finishes, providing a `Result` that contains either the successful output value or
+    ///   an error if the transducer failed.
     ///   - runTransducer: A closure which will be immediately called when the actor will be initialised.
     ///   It starts the transducer which runs in a Swift Task.
     ///   - content: A closure which takes the current state and the input as parameters and


### PR DESCRIPTION
Add Swift-DocC support and fix documentation warnings
    
    - Add swift-docc-plugin dependency for documentation generation
    - Add documentation generation and preview scripts
    - Fix all Swift-DocC warnings (missing parameters, invalid return docs)
    - Update completion parameter docs to reflect Completable API
    - Remove obsolete failure parameter documentation
    - Add missing isolated parameter documentation
