### PR TITLE
Fix if let view

### DIFF
--- a/Sources/Oak/Documentation.docc/Common-Patterns.md
+++ b/Sources/Oak/Documentation.docc/Common-Patterns.md
@@ -1,0 +1,532 @@
+# Common Patterns for State Machines
+
+Practical patterns and examples for modeling common application scenarios using Oak state machines.
+
+## Loading Data Pattern
+
+A fundamental pattern for handling asynchronous data loading with proper error handling and retry capabilities.
+
+```swift
+enum DataLoader: EffectTransducer {
+    enum State: NonTerminal {
+        case idle
+        case loading
+        case loaded([DataItem])
+        case error(Error, canRetry: Bool)
+    }
+    
+    enum Event {
+        case load
+        case reload
+        case dataReceived([DataItem])
+        case loadFailed(Error)
+        case retry
+        case dismiss
+    }
+    
+    struct Env: Sendable {
+        var dataService: @Sendable () async throws -> [DataItem]
+        var connectivity: @Sendable () -> Bool
+    }
+    
+    static var initialState: State { .idle }
+    
+    static func update(_ state: inout State, event: Event) -> Effect? {
+        switch (state, event) {
+        case (.idle, .load), (.error, .retry):
+            state = .loading
+            return loadDataEffect()
+            
+        case (.loaded, .reload):
+            state = .loading
+            return loadDataEffect()
+            
+        case (.loading, .dataReceived(let items)):
+            state = .loaded(items)
+            return nil
+            
+        case (.loading, .loadFailed(let error)):
+            let canRetry = error.isRetryable
+            state = .error(error, canRetry: canRetry)
+            return nil
+            
+        case (.error, .dismiss):
+            state = .idle
+            return nil
+            
+        default:
+            return nil
+        }
+    }
+    
+    static func loadDataEffect() -> Effect {
+        Effect(id: "loadData") { env, input in
+            do {
+                let items = try await env.dataService()
+                try input.send(.dataReceived(items))
+            } catch {
+                try input.send(.loadFailed(error))
+            }
+        }
+    }
+}
+
+extension Error {
+    var isRetryable: Bool {
+        // Implement retry logic based on error type
+        return true
+    }
+}
+```
+
+## Form Validation Pattern
+
+Managing complex forms with real-time validation and submission states.
+
+```swift
+enum UserForm: EffectTransducer {
+    struct FormData: Sendable {
+        var name: String = ""
+        var email: String = ""
+        var phone: String = ""
+        
+        var isValid: Bool {
+            !name.isEmpty && email.isValidEmail && phone.isValidPhone
+        }
+    }
+    
+    enum ValidationError: Error {
+        case invalidEmail
+        case invalidPhone
+        case nameRequired
+    }
+    
+    enum State: Terminable {
+        case editing(FormData, errors: [ValidationError])
+        case validating(FormData)
+        case submitting(FormData)
+        case submitted(result: SubmissionResult)
+        case cancelled
+        
+        var isTerminal: Bool {
+            switch self {
+            case .submitted, .cancelled: return true
+            case .editing, .validating, .submitting: return false
+            }
+        }
+    }
+    
+    enum Event {
+        case updateName(String)
+        case updateEmail(String)
+        case updatePhone(String)
+        case validate
+        case submit
+        case validationComplete([ValidationError])
+        case submissionComplete(SubmissionResult)
+        case cancel
+    }
+    
+    struct Env: Sendable {
+        var submitForm: @Sendable (FormData) async throws -> SubmissionResult
+        var validateForm: @Sendable (FormData) async -> [ValidationError]
+    }
+    
+    static var initialState: State {
+        .editing(FormData(), errors: [])
+    }
+    
+    static func update(_ state: inout State, event: Event) -> Effect? {
+        switch (state, event) {
+        case (.editing(var data, _), .updateName(let name)):
+            data.name = name
+            state = .editing(data, errors: [])
+            return validateEffect(data)
+            
+        case (.editing(var data, _), .updateEmail(let email)):
+            data.email = email
+            state = .editing(data, errors: [])
+            return validateEffect(data)
+            
+        case (.editing(var data, _), .updatePhone(let phone)):
+            data.phone = phone
+            state = .editing(data, errors: [])
+            return validateEffect(data)
+            
+        case (.editing(let data, _), .validationComplete(let errors)):
+            state = .editing(data, errors: errors)
+            return nil
+            
+        case (.editing(let data, let errors), .submit):
+            guard errors.isEmpty && data.isValid else { return nil }
+            state = .submitting(data)
+            return submitEffect(data)
+            
+        case (.submitting, .submissionComplete(let result)):
+            state = .submitted(result: result)
+            return nil
+            
+        case (_, .cancel):
+            state = .cancelled
+            return nil
+            
+        default:
+            return nil
+        }
+    }
+    
+    static func validateEffect(_ data: FormData) -> Effect {
+        Effect(id: "validate") { env, input in
+            let errors = await env.validateForm(data)
+            try input.send(.validationComplete(errors))
+        }
+    }
+    
+    static func submitEffect(_ data: FormData) -> Effect {
+        Effect { env, input in
+            do {
+                let result = try await env.submitForm(data)
+                try input.send(.submissionComplete(result))
+            } catch {
+                try input.send(.submissionComplete(.failure(error)))
+            }
+        }
+    }
+}
+```
+
+## Authentication Flow Pattern
+
+Complete authentication workflow with multiple steps and error recovery.
+
+```swift
+enum AuthFlow: EffectTransducer {
+    enum State: Terminable {
+        case unauthenticated
+        case enteringCredentials(email: String, password: String)
+        case authenticating(email: String, password: String)
+        case requiresTwoFactor(token: String, email: String)
+        case enteringTwoFactor(token: String, email: String, code: String)
+        case verifyingTwoFactor(token: String, email: String, code: String)
+        case authenticated(User)
+        case authenticationFailed(Error, canRetry: Bool)
+        case locked
+        
+        var isTerminal: Bool {
+            switch self {
+            case .authenticated, .locked: return true
+            default: return false
+            }
+        }
+    }
+    
+    enum Event {
+        case startLogin
+        case updateEmail(String)
+        case updatePassword(String)
+        case login
+        case authenticationSucceeded(User)
+        case authenticationFailed(Error)
+        case twoFactorRequired(token: String)
+        case updateTwoFactorCode(String)
+        case submitTwoFactor
+        case twoFactorVerified(User)
+        case twoFactorFailed(Error)
+        case retry
+        case logout
+        case accountLocked
+    }
+    
+    struct Env: Sendable {
+        var authenticate: @Sendable (String, String) async throws -> AuthResult
+        var verifyTwoFactor: @Sendable (String, String) async throws -> User
+        var maxAttempts: Int
+    }
+    
+    enum AuthResult {
+        case success(User)
+        case requiresTwoFactor(token: String)
+    }
+    
+    static var initialState: State { .unauthenticated }
+    
+    static func update(_ state: inout State, event: Event) -> Effect? {
+        switch (state, event) {
+        case (.unauthenticated, .startLogin):
+            state = .enteringCredentials(email: "", password: "")
+            return nil
+            
+        case (.enteringCredentials(_, let password), .updateEmail(let email)):
+            state = .enteringCredentials(email: email, password: password)
+            return nil
+            
+        case (.enteringCredentials(let email, _), .updatePassword(let password)):
+            state = .enteringCredentials(email: email, password: password)
+            return nil
+            
+        case (.enteringCredentials(let email, let password), .login):
+            state = .authenticating(email: email, password: password)
+            return authenticateEffect(email: email, password: password)
+            
+        case (.authenticating, .authenticationSucceeded(let user)):
+            state = .authenticated(user)
+            return nil
+            
+        case (.authenticating, .twoFactorRequired(let token)):
+            state = .requiresTwoFactor(token: token, email: extractEmail(from: state))
+            return nil
+            
+        case (.authenticating, .authenticationFailed(let error)):
+            let canRetry = !error.isAccountLocked
+            if error.isAccountLocked {
+                state = .locked
+            } else {
+                state = .authenticationFailed(error, canRetry: canRetry)
+            }
+            return nil
+            
+        case (.requiresTwoFactor(let token, let email), .updateTwoFactorCode(let code)):
+            state = .enteringTwoFactor(token: token, email: email, code: code)
+            return nil
+            
+        case (.enteringTwoFactor(let token, let email, let code), .submitTwoFactor):
+            state = .verifyingTwoFactor(token: token, email: email, code: code)
+            return verifyTwoFactorEffect(token: token, code: code)
+            
+        case (.verifyingTwoFactor, .twoFactorVerified(let user)):
+            state = .authenticated(user)
+            return nil
+            
+        case (.verifyingTwoFactor, .twoFactorFailed(let error)):
+            let token = extractToken(from: state)
+            let email = extractEmail(from: state)
+            state = .requiresTwoFactor(token: token, email: email)
+            return nil
+            
+        case (.authenticationFailed(_, true), .retry):
+            state = .enteringCredentials(email: "", password: "")
+            return nil
+            
+        case (.authenticated, .logout):
+            state = .unauthenticated
+            return nil
+            
+        default:
+            return nil
+        }
+    }
+    
+    static func authenticateEffect(email: String, password: String) -> Effect {
+        Effect { env, input in
+            do {
+                let result = try await env.authenticate(email, password)
+                switch result {
+                case .success(let user):
+                    try input.send(.authenticationSucceeded(user))
+                case .requiresTwoFactor(let token):
+                    try input.send(.twoFactorRequired(token))
+                }
+            } catch {
+                try input.send(.authenticationFailed(error))
+            }
+        }
+    }
+    
+    static func verifyTwoFactorEffect(token: String, code: String) -> Effect {
+        Effect { env, input in
+            do {
+                let user = try await env.verifyTwoFactor(token, code)
+                try input.send(.twoFactorVerified(user))
+            } catch {
+                try input.send(.twoFactorFailed(error))
+            }
+        }
+    }
+}
+```
+
+## Navigation Coordinator Pattern
+
+Managing complex navigation flows with state-driven routing.
+
+```swift
+enum AppNavigator: EffectTransducer {
+    enum Route: Hashable {
+        case home
+        case profile(User)
+        case settings
+        case login
+        case detail(Item)
+    }
+    
+    enum State: NonTerminal {
+        case navigating(stack: [Route], modal: Route?)
+    }
+    
+    enum Event {
+        case navigate(Route)
+        case push(Route)
+        case pop
+        case presentModal(Route)
+        case dismissModal
+        case reset
+    }
+    
+    static var initialState: State {
+        .navigating(stack: [.home], modal: nil)
+    }
+    
+    static func update(_ state: inout State, event: Event) -> Effect? {
+        switch (state, event) {
+        case (.navigating(_, let modal), .navigate(let route)):
+            state = .navigating(stack: [route], modal: modal)
+            return nil
+            
+        case (.navigating(var stack, let modal), .push(let route)):
+            stack.append(route)
+            state = .navigating(stack: stack, modal: modal)
+            return nil
+            
+        case (.navigating(var stack, let modal), .pop):
+            if stack.count > 1 {
+                stack.removeLast()
+            }
+            state = .navigating(stack: stack, modal: modal)
+            return nil
+            
+        case (.navigating(let stack, _), .presentModal(let route)):
+            state = .navigating(stack: stack, modal: route)
+            return nil
+            
+        case (.navigating(let stack, _), .dismissModal):
+            state = .navigating(stack: stack, modal: nil)
+            return nil
+            
+        case (.navigating, .reset):
+            state = .navigating(stack: [.home], modal: nil)
+            return nil
+            
+        default:
+            return nil
+        }
+    }
+}
+```
+
+## Timer and Polling Pattern
+
+Managing recurring operations with proper cancellation.
+
+```swift
+enum PollingService: EffectTransducer {
+    enum State: NonTerminal {
+        case idle
+        case polling(interval: TimeInterval, lastUpdate: Date?)
+        case paused(interval: TimeInterval, lastUpdate: Date?)
+    }
+    
+    enum Event {
+        case startPolling(interval: TimeInterval)
+        case stopPolling
+        case pausePolling
+        case resumePolling
+        case tick
+        case dataUpdated(Data)
+    }
+    
+    struct Env: Sendable {
+        var fetchData: @Sendable () async throws -> Data
+    }
+    
+    static var initialState: State { .idle }
+    
+    static func update(_ state: inout State, event: Event) -> Effect? {
+        switch (state, event) {
+        case (.idle, .startPolling(let interval)):
+            state = .polling(interval: interval, lastUpdate: nil)
+            return pollingEffect(interval: interval)
+            
+        case (.polling, .stopPolling), (.paused, .stopPolling):
+            state = .idle
+            return cancelPollingEffect()
+            
+        case (.polling(let interval, let lastUpdate), .pausePolling):
+            state = .paused(interval: interval, lastUpdate: lastUpdate)
+            return cancelPollingEffect()
+            
+        case (.paused(let interval, let lastUpdate), .resumePolling):
+            state = .polling(interval: interval, lastUpdate: lastUpdate)
+            return pollingEffect(interval: interval)
+            
+        case (.polling(let interval, _), .dataUpdated(let data)):
+            state = .polling(interval: interval, lastUpdate: Date())
+            return nil
+            
+        case (.polling(let interval, let lastUpdate), .tick):
+            state = .polling(interval: interval, lastUpdate: lastUpdate)
+            return fetchDataEffect()
+            
+        default:
+            return nil
+        }
+    }
+    
+    static func pollingEffect(interval: TimeInterval) -> Effect {
+        Effect(id: "polling") { env, input in
+            while !Task.isCancelled {
+                try input.send(.tick)
+                try await Task.sleep(for: .seconds(interval))
+            }
+        }
+    }
+    
+    static func fetchDataEffect() -> Effect {
+        Effect { env, input in
+            do {
+                let data = try await env.fetchData()
+                try input.send(.dataUpdated(data))
+            } catch {
+                // Handle error appropriately
+            }
+        }
+    }
+    
+    static func cancelPollingEffect() -> Effect {
+        Effect.cancel(id: "polling")
+    }
+}
+```
+
+## Pattern Selection Guidelines
+
+### Use Loading Data Pattern When:
+- Fetching data from APIs or databases
+- Need clear loading states and error handling
+- Want retry capabilities
+- Handling network connectivity issues
+
+### Use Form Validation Pattern When:
+- Building complex forms with multiple fields
+- Need real-time validation feedback
+- Want to prevent invalid submissions
+- Handling multi-step form workflows
+
+### Use Authentication Flow Pattern When:
+- Implementing login/logout functionality
+- Supporting multi-factor authentication
+- Need account lockout protection
+- Want clear authentication state tracking
+
+### Use Navigation Coordinator Pattern When:
+- Managing complex navigation hierarchies
+- Need programmatic navigation control
+- Want to decouple navigation from views
+- Supporting modal presentations
+
+### Use Timer/Polling Pattern When:
+- Need periodic data updates
+- Building real-time features
+- Want controllable background operations
+- Need proper cleanup on view disappearance
+
+These patterns provide starting points for common scenarios. Adapt them to your specific requirements while maintaining Oak's principles of explicit state modeling and pure transition functions.

--- a/Sources/Oak/Documentation.docc/Effects.md
+++ b/Sources/Oak/Documentation.docc/Effects.md
@@ -1,0 +1,431 @@
+# Effects and Side Effect Management
+
+Effects provide Oak's mechanism for handling side effects while maintaining pure state transition logic. This separation enables predictable, testable state machines that can still interact with the external world.
+
+## The Pure Update Function Foundation
+
+Understanding Effects requires understanding Oak's core architectural principle: the pure `update` function. Every Oak transducer centers around this function:
+
+```swift
+static func update(_ state: inout State, event: Event) -> Output
+// or for EffectTransducers:
+static func update(_ state: inout State, event: Event) -> Effect?
+static func update(_ state: inout State, event: Event) -> (Effect?, Output)
+```
+
+**Pure means:**
+- No side effects whatsoever - no network calls, file operations, logging, or external interactions
+- Deterministic - same inputs always produce same outputs
+- No dependencies on external state or time
+- Only transforms the provided state and returns a result
+
+This purity is what makes Oak transducers predictable, testable, and debuggable. But real applications need to interact with the outside world - that's where Effects come in.
+
+**Effects bridge the pure-impure divide:** The `update` function can create Effect descriptions safely (pure), but Oak's runtime executes them later (impure). This keeps state transitions predictable while enabling real-world functionality.
+
+> For comprehensive coverage of the `update` function signatures, patterns, theoretical foundation, and implementation details, see <doc:Transducers>.
+
+## Understanding Side Effects vs Effects
+
+**Side Effect** (concept): Any operation that interacts with systems outside your state machine or produces observable changes beyond returning a value. Examples include network requests, file operations, or printing to console.
+
+**Effect** (Oak's implementation): A declarative description of an async throwing function that will be executed by Oak's runtime. Effects are created safely in the pure `update` function, but the actual execution happens later under Oak's management.
+
+## Understanding Side Effects
+
+Side effects are operations that interact with systems outside your state machine:
+
+- Network requests and HTTP calls
+- File system operations
+- Database queries
+- Timer operations and delays
+- Logging and analytics
+- Hardware interactions
+- UI updates beyond state changes
+
+Oak's architecture requires that all side effects be handled through the Effect system, keeping the `update` function pure and deterministic.
+
+## Effect Types
+
+Oak provides two types of effects with different execution characteristics:
+
+### Operation Effects
+
+Operation effects perform asynchronous work and can send zero or more events back to the transducer during their lifecycle. Common examples include network requests and timers:
+
+```swift
+// Network request - external side effect, sends one event after completion
+static func loadUserEffect(userId: String) -> Effect {
+    Effect(id: "loadUser-\(userId)") { env, input in
+        do {
+            let user = try await env.userService.fetchUser(id: userId)
+            try input.send(.userLoaded(user))
+        } catch {
+            try input.send(.userLoadFailed(error))
+        }
+    }
+}
+
+// Timer - minimal side effect, sends multiple events over time
+static func timerEffect(interval: TimeInterval) -> Effect {
+    Effect(id: "timer") { env, input in
+        while !Task.isCancelled {
+            try await Task.sleep(for: .seconds(interval))
+            try input.send(.tick)
+        }
+    }
+}
+```
+
+**Characteristics:**
+- Executed asynchronously as managed Tasks
+- Can send zero or more events during their lifecycle via Input
+- Support cancellation via effect IDs
+- Run concurrently with the transducer
+
+### Action Effects
+
+Action effects return zero or more events from their function, which are handled immediately in the transducer logic:
+
+```swift
+static func configurationEffect() -> Effect {
+    Effect.action { env in
+        let config = env.loadConfiguration()
+        return [.configLoaded(config), .ready] // Returns events immediately
+    }
+}
+```
+
+**Characteristics:**
+- Executed immediately and synchronously
+- Return events directly from the function for immediate processing
+- Events are processed before any operation effects start
+- Useful for environment data import, immediate computations
+
+## Effect Creation Patterns
+
+### Basic Operation Effect
+
+```swift
+static func networkRequestEffect() -> Effect {
+    Effect { env, input in
+        let data = try await env.networkService.fetchData()
+        try input.send(.dataReceived(data))
+    }
+}
+```
+
+### Effect with Cancellation ID
+
+Use IDs to enable cancellation of ongoing effects:
+
+```swift
+static func searchEffect(query: String) -> Effect {
+    Effect(id: "search-\(query)") { env, input in
+        let results = try await env.searchService.search(query: query)
+        try input.send(.searchResults(results))
+    }
+}
+```
+
+When a new search starts, the previous search effect is automatically cancelled.
+
+### Error Handling in Effects
+
+```swift
+static func risky operationEffect() -> Effect {
+    Effect { env, input in
+        do {
+            let result = try await env.riskyService.performOperation()
+            try input.send(.operationSucceeded(result))
+        } catch let error as NetworkError {
+            try input.send(.networkError(error))
+        } catch {
+            try input.send(.unknownError(error))
+        }
+    }
+}
+```
+
+### Composite Effects
+
+Combine multiple effects for complex operations:
+
+```swift
+static func saveAndBackupEffect(data: Data) -> Effect {
+    Effect { env, input in
+        // Save locally first
+        try await env.localStorage.save(data)
+        
+        // Then backup to remote
+        try await env.remoteBackup.upload(data)
+        
+        try input.send(.saveCompleted)
+    }
+}
+```
+
+## Environment Design
+
+The Environment (`Env`) provides dependencies to effects in a type-safe, testable way.
+
+### Service Dependencies
+
+```swift
+struct Env: Sendable {
+    var userService: @Sendable (String) async throws -> User
+    var analyticsService: @Sendable (String) -> Void
+    var localStorage: @Sendable (Data) throws -> Void
+}
+```
+
+### Configuration Parameters
+
+```swift
+struct Env: Sendable {
+    var maxRetries: Int
+    var requestTimeout: TimeInterval
+    var baseURL: URL
+    var featureFlags: FeatureFlags
+}
+```
+
+### Sendable Compliance
+
+All environment properties must be `@Sendable` for safe concurrent access:
+
+```swift
+// Good: Sendable closure
+var dataService: @Sendable () async throws -> [DataItem]
+
+// Good: Sendable actor
+var dataManager: DataManagerActor
+
+// Avoid: Non-sendable references
+var dataController: NSManagedObjectContext // Not Sendable
+```
+
+## Effect Lifecycle
+
+### Automatic Cancellation
+
+Effects are automatically cancelled when:
+
+- The transducer reaches a terminal state
+- A new effect with the same ID is created
+- The SwiftUI view containing the transducer disappears
+
+### Manual Cancellation
+
+Cancel effects explicitly by returning cancellation effects:
+
+```swift
+static func cancelLoadingEffect() -> Effect {
+    Effect.cancel(id: "dataLoading")
+}
+```
+
+### Effect Ordering
+
+Action effects always execute before operation effects:
+
+```swift
+static func update(_ state: inout State, event: Event) -> Effect? {
+    switch (state, event) {
+    case (.idle, .start):
+        state = .starting
+        return .sequence([
+            logEffect("Starting operation"),  // Action: executes first
+            loadDataEffect()                 // Operation: executes second
+        ])
+    }
+}
+```
+
+## Testing Effects
+
+### Mocking Environments
+
+Create test environments with predictable behavior:
+
+```swift
+extension MyTransducer.Env {
+    static var test: Self {
+        Self(
+            dataService: { MockData.items },
+            logger: { _ in }, // No-op logger for tests
+            analytics: { _ in } // No-op analytics
+        )
+    }
+}
+```
+
+### Testing Effect Behavior
+
+Test effects by verifying the events they send:
+
+```swift
+func testLoadDataEffect() async throws {
+    let expectation = XCTestExpectation(description: "Data loaded")
+    var receivedEvent: MyTransducer.Event?
+    
+    let input = MockInput { event in
+        receivedEvent = event
+        expectation.fulfill()
+    }
+    
+    let env = MyTransducer.Env.test
+    let effect = MyTransducer.loadDataEffect()
+    
+    try await effect.run(env: env, input: input)
+    
+    await fulfillment(of: [expectation], timeout: 1.0)
+    
+    if case .dataLoaded(let items) = receivedEvent {
+        XCTAssertEqual(items.count, MockData.items.count)
+    } else {
+        XCTFail("Expected dataLoaded event")
+    }
+}
+```
+
+## Error Handling Strategies
+
+### Graceful Degradation
+
+Handle errors by transitioning to recovery states:
+
+```swift
+static func update(_ state: inout State, event: Event) -> Effect? {
+    switch (state, event) {
+    case (.loading, .loadFailed(let error)):
+        if error.isRetryable {
+            state = .retryable(error: error, attempt: 1)
+            return retryEffect(delay: 1.0)
+        } else {
+            state = .failed(error)
+            return alertEffect("Operation failed")
+        }
+    }
+}
+```
+
+### Retry Logic
+
+Implement retry with exponential backoff:
+
+```swift
+static func retryEffect(delay: TimeInterval) -> Effect {
+    Effect { env, input in
+        try await Task.sleep(for: .seconds(delay))
+        try input.send(.retry)
+    }
+}
+```
+
+### Error Context Preservation
+
+Maintain error context for debugging:
+
+```swift
+enum State {
+    case failed(operation: String, error: Error, context: [String: Any])
+}
+```
+
+## Performance Optimization
+
+### Effect Reuse
+
+Reuse effect instances when possible:
+
+```swift
+private static let refreshEffect = Effect { env, input in
+    let data = try await env.dataService.refresh()
+    try input.send(.refreshCompleted(data))
+}
+
+static func update(_ state: inout State, event: Event) -> Effect? {
+    switch (state, event) {
+    case (.idle, .refresh):
+        return refreshEffect // Reuse instead of recreating
+    }
+}
+```
+
+### Avoid Heavy Computation in Effects
+
+Keep effects focused on I/O operations:
+
+```swift
+// Good: Effect handles I/O, computation in update
+static func processDataEffect(data: RawData) -> Effect {
+    Effect { env, input in
+        let processedData = await env.processor.process(data)
+        try input.send(.dataProcessed(processedData))
+    }
+}
+
+// Avoid: Heavy computation in effect
+static func heavyComputationEffect(data: RawData) -> Effect {
+    Effect { env, input in
+        // Expensive computation blocks the effect system
+        let result = performExpensiveCalculation(data)
+        try input.send(.calculationComplete(result))
+    }
+}
+```
+
+## Common Effect Patterns
+
+### Debounced Effects
+
+Implement debouncing using effect IDs:
+
+```swift
+static func searchEffect(query: String) -> Effect {
+    Effect(id: "search") { env, input in
+        try await Task.sleep(for: .milliseconds(300)) // Debounce
+        let results = try await env.searchService.search(query: query)
+        try input.send(.searchResults(results))
+    }
+}
+```
+
+### Polling Effects
+
+Create recurring operations:
+
+```swift
+static func pollStatusEffect() -> Effect {
+    Effect(id: "polling") { env, input in
+        while !Task.isCancelled {
+            let status = try await env.statusService.checkStatus()
+            try input.send(.statusUpdated(status))
+            try await Task.sleep(for: .seconds(5))
+        }
+    }
+}
+```
+
+### Cleanup Effects
+
+Perform cleanup when leaving states:
+
+```swift
+static func update(_ state: inout State, event: Event) -> Effect? {
+    switch (state, event) {
+    case (.streaming, .stop):
+        state = .idle
+        return cleanupEffect()
+    }
+}
+
+static func cleanupEffect() -> Effect {
+    Effect.action { env in
+        env.streamManager.closeConnections()
+    }
+}
+```
+
+Effects provide a powerful, type-safe way to handle side effects while maintaining the purity and predictability of your state machines. The key is keeping effects focused, testable, and properly integrated with your application's lifecycle.

--- a/Sources/Oak/Documentation.docc/Finite-State-Machines.md
+++ b/Sources/Oak/Documentation.docc/Finite-State-Machines.md
@@ -1,0 +1,258 @@
+# Understanding Finite State Machines
+
+Finite state machines provide mathematical guarantees about application behavior by making all possible states and transitions explicit.
+
+## The Problem with Implicit State
+
+Most applications manage state implicitly through scattered boolean flags and optional properties:
+
+```swift
+class ViewController {
+    var isLoading = false
+    var hasError = false
+    var data: [Item]?
+    var errorMessage: String?
+    
+    func loadData() {
+        // What if isLoading is already true?
+        // What if hasError is true but errorMessage is nil?
+        // How many total states are possible here?
+    }
+}
+```
+
+This approach creates several problems:
+
+**State Explosion**: With multiple boolean flags, the number of possible states grows exponentially. Four boolean properties create 16 possible combinations, but most are invalid or undefined.
+
+**Race Conditions**: Concurrent updates to multiple properties can create inconsistent intermediate states.
+
+**Undefined Behavior**: Invalid state combinations lead to unpredictable application behavior.
+
+**Testing Complexity**: All possible state combinations must be tested, including invalid ones.
+
+## Finite State Machine Solution
+
+A finite state machine (FSM) explicitly defines:
+
+- **States**: All possible conditions the system can be in
+- **Events**: All possible inputs that can trigger changes
+- **Transitions**: Which events cause which state changes
+- **Actions**: What happens during each transition
+
+### Mathematical Guarantees
+
+FSMs provide formal guarantees:
+
+1. **Completeness**: Every (state, event) combination is handled
+2. **Determinism**: Each (state, event) pair has exactly one outcome
+3. **Reachability**: All states can be reached from the initial state
+4. **Termination**: Terminal states are clearly defined
+
+## Oak's FSM Implementation
+
+Oak implements FSMs through the `Transducer` protocol:
+
+```swift
+enum LoginFlow: Transducer {
+    // Explicit state definition
+    enum State: Terminable {
+        case start
+        case enteringCredentials(email: String, password: String)
+        case authenticating(email: String, password: String)
+        case authenticated(User)
+        case failed(Error)
+        case completed
+        
+        var isTerminal: Bool {
+            if case .completed = self { return true }
+            return false
+        }
+    }
+    
+    // All possible events
+    enum Event {
+        case startLogin
+        case updateEmail(String)
+        case updatePassword(String)
+        case submitCredentials
+        case authenticationSucceeded(User)
+        case authenticationFailed(Error)
+        case loginComplete
+    }
+    
+    // Pure transition function
+    static func update(_ state: inout State, event: Event) -> Void {
+        switch (state, event) {
+        case (.start, .startLogin):
+            state = .enteringCredentials(email: "", password: "")
+            
+        case (.enteringCredentials(_, let password), .updateEmail(let email)):
+            state = .enteringCredentials(email: email, password: password)
+            
+        case (.enteringCredentials(let email, _), .updatePassword(let password)):
+            state = .enteringCredentials(email: email, password: password)
+            
+        case (.enteringCredentials(let email, let password), .submitCredentials):
+            state = .authenticating(email: email, password: password)
+            
+        case (.authenticating, .authenticationSucceeded(let user)):
+            state = .authenticated(user)
+            
+        case (.authenticating, .authenticationFailed(let error)):
+            state = .failed(error)
+            
+        case (.authenticated, .loginComplete):
+            state = .completed
+            
+        case (.failed, .startLogin):
+            state = .enteringCredentials(email: "", password: "")
+            
+        default:
+            // Invalid transitions are explicitly ignored
+            break
+        }
+    }
+}
+```
+
+## Benefits of Explicit State Modeling
+
+### Impossible States are Unrepresentable
+
+```swift
+// MVVM: All these combinations are possible
+isLoading = true
+hasData = true
+hasError = true  // Loading with data AND error?
+
+// Oak: Only valid states can exist
+enum State {
+    case loading        // Definitely loading, no data, no error
+    case loaded(Data)   // Definitely has data, not loading, no error
+    case error(Error)   // Definitely has error, not loading, no data
+}
+```
+
+### Exhaustive Transition Handling
+
+The compiler enforces complete event handling:
+
+```swift
+switch (state, event) {
+case (.idle, .start): // Must handle every combination
+case (.loading, .complete):
+case (.loading, .fail):
+// Compiler error if any combination is missing
+}
+```
+
+### Predictable Behavior
+
+Every state transition is deterministic:
+
+```swift
+var state = LoginFlow.State.start
+LoginFlow.update(&state, event: .startLogin)
+// state is guaranteed to be .enteringCredentials("", "")
+```
+
+## State Design Principles
+
+### Use Enums for Distinct States
+
+Prefer sum types (enums) over product types (structs) for state:
+
+```swift
+// Good: Mutually exclusive states
+enum ConnectionState {
+    case disconnected
+    case connecting
+    case connected(Session)
+    case reconnecting(lastSession: Session)
+}
+
+// Avoid: Multiple properties that can create invalid combinations
+struct ConnectionState {
+    var isConnected: Bool
+    var isConnecting: Bool
+    var session: Session?
+    var isReconnecting: Bool
+}
+```
+
+### Include Relevant Data in States
+
+States can carry associated data:
+
+```swift
+enum FormState {
+    case editing(fields: [String: String], errors: [ValidationError])
+    case validating(fields: [String: String])
+    case valid(submissionData: SubmissionData)
+    case submitting(submissionData: SubmissionData)
+    case submitted(result: SubmissionResult)
+}
+```
+
+### Model Terminal States Explicitly
+
+Some states represent completion:
+
+```swift
+enum ProcessState: Terminable {
+    case initializing
+    case processing(progress: Double)
+    case completed(result: Result)
+    case cancelled
+    case failed(Error)
+    
+    var isTerminal: Bool {
+        switch self {
+        case .completed, .cancelled, .failed:
+            return true
+        case .initializing, .processing:
+            return false
+        }
+    }
+}
+```
+
+## Testing FSM Logic
+
+FSMs are easy to test because transitions are pure functions:
+
+```swift
+func testLoginFlow() {
+    var state = LoginFlow.State.start
+    
+    // Test transition
+    LoginFlow.update(&state, event: .startLogin)
+    
+    // Verify result
+    if case .enteringCredentials(let email, let password) = state {
+        XCTAssertEqual(email, "")
+        XCTAssertEqual(password, "")
+    } else {
+        XCTFail("Expected enteringCredentials state")
+    }
+}
+```
+
+## When to Use FSMs
+
+FSMs excel when:
+
+- **Clear Phases**: Your feature has distinct operational phases
+- **Complex State**: Multiple interacting boolean flags create confusion
+- **Race Conditions**: Concurrent operations cause state corruption
+- **Error Recovery**: Different error types require different recovery paths
+- **Audit Requirements**: You need clear state transition logs
+
+FSMs may be overkill for:
+
+- Simple views with minimal state
+- Purely computational tasks
+- Features with only trivial state changes
+
+The key is recognizing when explicit state modeling provides value over implicit state management.

--- a/Sources/Oak/Documentation.docc/First-State-Machine.md
+++ b/Sources/Oak/Documentation.docc/First-State-Machine.md
@@ -1,0 +1,140 @@
+# Your First State Machine
+
+Learn Oak fundamentals by building a simple counter that demonstrates state transitions and event handling.
+
+## Understanding the Problem
+
+Traditional counter implementations often suffer from race conditions and undefined states. Consider this common pattern:
+
+```swift
+class CounterViewModel: ObservableObject {
+    @Published var count = 0
+    @Published var isLoading = false
+    
+    func increment() {
+        // What if this is called multiple times quickly?
+        // What if isLoading is true but we still increment?
+        count += 1
+    }
+}
+```
+
+This approach leaves many questions unanswered about valid states and transitions.
+
+## Oak's Approach
+
+Oak requires explicit definition of all possible states and the events that trigger transitions between them.
+
+### Defining State
+
+Start by modeling your application's states as a Swift enum:
+
+```swift
+enum CounterState: NonTerminal {
+    case idle(count: Int)
+    case incrementing(count: Int)
+    case decrementing(count: Int)
+}
+```
+
+The `NonTerminal` protocol indicates this state machine never reaches a final state.
+
+### Defining Events
+
+Events represent user actions or system events that can trigger state changes:
+
+```swift
+enum CounterEvent {
+    case increment
+    case decrement
+    case incrementComplete
+    case decrementComplete
+}
+```
+
+### Creating the Transducer
+
+Combine state and events into a transducer that defines valid transitions:
+
+```swift
+import Oak
+
+enum Counter: Transducer {
+    enum State: NonTerminal {
+        case idle(count: Int)
+        case incrementing(count: Int)
+        case decrementing(count: Int)
+        
+        var count: Int {
+            switch self {
+            case .idle(let count), .incrementing(let count), .decrementing(let count):
+                return count
+            }
+        }
+    }
+    
+    enum Event {
+        case increment
+        case decrement
+        case incrementComplete
+        case decrementComplete
+    }
+    
+    typealias Output = Int
+    
+    static var initialState: State {
+        .idle(count: 0)
+    }
+    
+    static func update(_ state: inout State, event: Event) -> Output {
+        switch (state, event) {
+        case (.idle(let count), .increment):
+            state = .incrementing(count: count)
+            return count
+            
+        case (.idle(let count), .decrement):
+            state = .decrementing(count: count)
+            return count
+            
+        case (.incrementing(let count), .incrementComplete):
+            let newCount = count + 1
+            state = .idle(count: newCount)
+            return newCount
+            
+        case (.decrementing(let count), .decrementComplete):
+            let newCount = max(0, count - 1)
+            state = .idle(count: newCount)
+            return newCount
+            
+        // Ignore increment/decrement during processing
+        case (.incrementing, .increment), (.incrementing, .decrement),
+             (.decrementing, .increment), (.decrementing, .decrement):
+            return state.count
+            
+        // Handle unexpected combinations
+        default:
+            return state.count
+        }
+    }
+    
+    static func initialOutput(initialState: State) -> Output? {
+        return initialState.count
+    }
+}
+```
+
+## Key Concepts Demonstrated
+
+**Pure Functions**: The `update` function contains no side effects and produces deterministic results for any given state and event combination.
+
+**Explicit State Modeling**: Every possible state is defined in the type system. Impossible states cannot be represented.
+
+**Exhaustive Event Handling**: All event combinations must be handled explicitly. The compiler enforces completeness.
+
+**Output Generation**: Transducers can produce output values that represent the result of state transitions.
+
+## What's Next
+
+This basic transducer handles state transitions but doesn't integrate with UI yet. The next section shows how to connect this state machine to SwiftUI views.
+
+See <doc:SwiftUI-Basics> for UI integration or <doc:Effects> for handling asynchronous operations.

--- a/Sources/Oak/Documentation.docc/Installation.md
+++ b/Sources/Oak/Documentation.docc/Installation.md
@@ -1,0 +1,46 @@
+# Installation
+
+Add Oak to your Swift package or Xcode project.
+
+## Swift Package Manager
+
+Add Oak as a dependency in your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/couchdeveloper/Oak.git", from: "1.0.0")
+]
+```
+
+Then add Oak to your target:
+
+```swift
+.target(
+    name: "YourTarget",
+    dependencies: ["Oak"]
+)
+```
+
+## Xcode Projects
+
+1. In Xcode, select **File → Add Package Dependencies**
+2. Enter the repository URL: `https://github.com/couchdeveloper/Oak.git`
+3. Select your version requirements
+4. Add Oak to your target
+
+## Platform Requirements
+
+Oak requires:
+- iOS 15.0+ / macOS 12.0+ / tvOS 15.0+ / watchOS 8.0+
+- Swift 6.2+
+- Xcode 15.0+
+
+## Importing Oak
+
+Import Oak in your Swift files:
+
+```swift
+import Oak
+```
+
+For SwiftUI integration, Oak is designed to work directly with SwiftUI views without additional imports.

--- a/Sources/Oak/Documentation.docc/MVVM-to-Oak.md
+++ b/Sources/Oak/Documentation.docc/MVVM-to-Oak.md
@@ -1,0 +1,408 @@
+# Migrating from MVVM to Oak
+
+A practical guide for converting MVVM ViewModels to Oak's state machine approach, with side-by-side comparisons and migration strategies.
+
+## Understanding the Differences
+
+### MVVM Approach
+
+MVVM relies on observable properties and imperative state updates:
+
+```swift
+class DataListViewModel: ObservableObject {
+    @Published var items: [DataItem] = []
+    @Published var isLoading = false
+    @Published var error: Error?
+    @Published var showingError = false
+    
+    func loadData() {
+        guard !isLoading else { return }
+        
+        isLoading = true
+        error = nil
+        
+        dataService.fetchItems { [weak self] result in
+            DispatchQueue.main.async {
+                self?.isLoading = false
+                switch result {
+                case .success(let items):
+                    self?.items = items
+                case .failure(let error):
+                    self?.error = error
+                    self?.showingError = true
+                }
+            }
+        }
+    }
+    
+    func dismissError() {
+        showingError = false
+        error = nil
+    }
+}
+```
+
+### Oak Approach
+
+Oak models the same functionality as explicit states and transitions:
+
+```swift
+enum DataListTransducer: EffectTransducer {
+    enum State: NonTerminal {
+        case idle
+        case loading
+        case loaded([DataItem])
+        case error(Error)
+    }
+    
+    enum Event {
+        case loadData
+        case dataLoaded([DataItem])
+        case loadFailed(Error)
+        case dismissError
+    }
+    
+    struct Env: Sendable {
+        var dataService: @Sendable () async throws -> [DataItem]
+    }
+    
+    static var initialState: State { .idle }
+    
+    static func update(_ state: inout State, event: Event) -> Effect? {
+        switch (state, event) {
+        case (.idle, .loadData), (.error, .loadData):
+            state = .loading
+            return .loadData
+            
+        case (.loading, .dataLoaded(let items)):
+            state = .loaded(items)
+            return nil
+            
+        case (.loading, .loadFailed(let error)):
+            state = .error(error)
+            return nil
+            
+        case (.error, .dismissError):
+            state = .idle
+            return nil
+            
+        default:
+            return nil
+        }
+    }
+    
+    static func loadDataEffect() -> Effect {
+        Effect { env, input in
+            do {
+                let items = try await env.dataService()
+                try input.send(.dataLoaded(items))
+            } catch {
+                try input.send(.loadFailed(error))
+            }
+        }
+    }
+}
+```
+
+## Key Differences Explained
+
+### State Representation
+
+**MVVM**: Multiple boolean flags and optional properties can create invalid combinations:
+- `isLoading = true` and `error != nil` (loading with error?)
+- `items.isEmpty` and `isLoading = false` (loaded but empty?)
+
+**Oak**: Single enum state prevents invalid combinations:
+- `.loading` means definitely loading, no data, no error
+- `.loaded([])` means successfully loaded empty data
+- `.error(Error)` means definitely failed, no partial data
+
+### State Updates
+
+**MVVM**: Imperative updates scattered across methods:
+```swift
+self?.isLoading = false  // Could be called from multiple places
+self?.error = error      // Might conflict with other updates
+```
+
+**Oak**: Centralized, pure state transitions:
+```swift
+// All state changes happen in one place with explicit rules
+static func update(_ state: inout State, event: Event) -> Effect?
+```
+
+### Error Handling
+
+**MVVM**: Manual error state management:
+```swift
+self?.error = error
+self?.showingError = true  // Separate flag for UI state
+```
+
+**Oak**: Error states are first-class:
+```swift
+case (.loading, .loadFailed(let error)):
+    state = .error(error)  // Error is the state, not a property
+```
+
+## Migration Steps
+
+### Step 1: Identify States
+
+Look at your ViewModel's `@Published` properties and identify mutually exclusive states:
+
+```swift
+// MVVM properties
+@Published var isLoading = false
+@Published var items: [Item] = []
+@Published var error: Error?
+
+// Becomes Oak states
+enum State {
+    case idle
+    case loading
+    case loaded([Item])
+    case error(Error)
+}
+```
+
+### Step 2: Convert Methods to Events
+
+Transform ViewModel methods into events:
+
+```swift
+// MVVM methods
+func loadData() { ... }
+func refresh() { ... }
+func dismissError() { ... }
+
+// Becomes Oak events
+enum Event {
+    case loadData
+    case refresh
+    case dismissError
+    case dataLoaded([Item])
+    case loadFailed(Error)
+}
+```
+
+### Step 3: Move Async Operations to Effects
+
+Extract async operations from methods into effects:
+
+```swift
+// MVVM async in method
+func loadData() {
+    dataService.fetchItems { result in
+        // Handle result...
+    }
+}
+
+// Oak effect
+static func loadDataEffect() -> Effect {
+    Effect { env, input in
+        do {
+            let items = try await env.dataService()
+            try input.send(.dataLoaded(items))
+        } catch {
+            try input.send(.loadFailed(error))
+        }
+    }
+}
+```
+
+### Step 4: Replace ViewModel with TransducerView
+
+Convert your SwiftUI view from using `@StateObject` to `TransducerView`:
+
+```swift
+// MVVM view
+struct DataListView: View {
+    @StateObject private var viewModel = DataListViewModel()
+    
+    var body: some View {
+        Group {
+            if viewModel.isLoading {
+                ProgressView()
+            } else if let error = viewModel.error {
+                ErrorView(error: error) {
+                    viewModel.dismissError()
+                }
+            } else {
+                List(viewModel.items) { item in
+                    ItemRow(item: item)
+                }
+            }
+        }
+        .onAppear {
+            viewModel.loadData()
+        }
+    }
+}
+
+// Oak view
+struct DataListView: View {
+    @State private var state = DataListTransducer.initialState
+    @Environment(\.dataListEnv) var env
+    
+    var body: some View {
+        TransducerView(
+            of: DataListTransducer.self,
+            initialState: $state,
+            env: env
+        ) { state, input in
+            Group {
+                switch state {
+                case .idle:
+                    Button("Load Data") {
+                        try? input.send(.loadData)
+                    }
+                    
+                case .loading:
+                    ProgressView()
+                    
+                case .loaded(let items):
+                    List(items) { item in
+                        ItemRow(item: item)
+                    }
+                    
+                case .error(let error):
+                    ErrorView(error: error) {
+                        try? input.send(.dismissError)
+                    }
+                }
+            }
+        }
+        .onAppear {
+            if case .idle = state {
+                try? input.send(.loadData)
+            }
+        }
+    }
+}
+```
+
+## Common Migration Patterns
+
+### Loading States
+
+**MVVM Pattern**:
+```swift
+@Published var isLoading = false
+@Published var data: Data?
+```
+
+**Oak Pattern**:
+```swift
+enum State {
+    case idle
+    case loading
+    case loaded(Data)
+}
+```
+
+### Error Handling
+
+**MVVM Pattern**:
+```swift
+@Published var error: Error?
+@Published var showingError = false
+```
+
+**Oak Pattern**:
+```swift
+enum State {
+    case error(Error, canRetry: Bool)
+}
+
+enum Event {
+    case dismissError
+    case retry
+}
+```
+
+### Form Validation
+
+**MVVM Pattern**:
+```swift
+@Published var email = ""
+@Published var password = ""
+@Published var emailError: String?
+@Published var passwordError: String?
+@Published var isValid = false
+```
+
+**Oak Pattern**:
+```swift
+enum State {
+    case editing(email: String, password: String, validation: ValidationState)
+    case submitting(email: String, password: String)
+    case submitted
+}
+
+enum ValidationState {
+    case valid
+    case invalid([ValidationError])
+}
+```
+
+## Benefits After Migration
+
+### Compile-Time Safety
+
+Oak prevents invalid state combinations that are possible in MVVM:
+
+```swift
+// MVVM: This is possible but invalid
+viewModel.isLoading = true
+viewModel.error = someError  // Loading AND error?
+
+// Oak: This is impossible to represent
+// States are mutually exclusive by design
+```
+
+### Predictable State Changes
+
+Oak's pure functions make state changes predictable and testable:
+
+```swift
+// MVVM: Hard to test all state combinations
+func testErrorHandling() {
+    viewModel.isLoading = true
+    // Simulate network error...
+    // What if isLoading doesn't get set to false?
+}
+
+// Oak: Easy to test pure functions
+func testErrorHandling() {
+    var state = DataListTransducer.State.loading
+    let effect = DataListTransducer.update(&state, event: .loadFailed(testError))
+    XCTAssertEqual(state, .error(testError))
+    XCTAssertNil(effect)
+}
+```
+
+### Easier Debugging
+
+State machines provide clear audit trails:
+
+```swift
+// Oak: State transitions are explicit
+.idle → .loading (loadData event)
+.loading → .error(NetworkError) (loadFailed event)
+.error(NetworkError) → .idle (dismissError event)
+```
+
+## Migration Checklist
+
+- [ ] Identify all possible states from `@Published` properties
+- [ ] Convert ViewModel methods to events
+- [ ] Extract async operations into effects
+- [ ] Define environment for dependencies
+- [ ] Replace `@StateObject` with `@State` and `TransducerView`
+- [ ] Update SwiftUI view to use state-driven UI
+- [ ] Add environment injection for effects
+- [ ] Test state transitions in isolation
+- [ ] Verify no invalid state combinations exist
+
+The result is more predictable, testable, and maintainable code with stronger compile-time guarantees.

--- a/Sources/Oak/Documentation.docc/Oak.md
+++ b/Sources/Oak/Documentation.docc/Oak.md
@@ -1,0 +1,76 @@
+# Oak Framework
+
+A type-safe finite state machine library for Swift with powerful effect handling and seamless SwiftUI integration.
+
+## Overview
+
+Oak provides a structured approach to application state management through finite state machines (FSMs). Unlike traditional state management patterns that rely on imperative updates and manual synchronization, Oak enforces explicit state transitions with compile-time guarantees about application behavior.
+
+### Key Benefits
+
+**Type Safety**: Oak leverages Swift's type system to prevent invalid state transitions at compile time. Every possible state and event combination must be explicitly handled, eliminating undefined behavior.
+
+**Predictable State Changes**: State transitions follow mathematical rules defined in pure functions. This deterministic approach makes application behavior predictable and reproducible.
+
+**Effect Isolation**: Side effects are separated from state logic through Oak's Effect system. This separation improves testability and makes complex async operations manageable.
+
+**SwiftUI Native**: Oak integrates directly with SwiftUI's reactive system through `TransducerView` and environment injection, requiring no external dependencies or view model layers.
+
+**Concurrent Safety**: Built on Swift's structured concurrency model with proper actor isolation and `Sendable` compliance throughout.
+
+### When to Use Oak
+
+Oak excels in scenarios requiring reliable state management:
+
+- Multi-step workflows with clear phases (onboarding, checkout, data loading)
+- Complex forms with validation and error states
+- Features requiring precise state coordination (authentication flows, real-time updates)
+- Applications where state bugs have serious consequences
+- Teams wanting to reduce state-related debugging time
+
+Oak may be unnecessary for simple views with minimal state requirements or applications with very basic user interactions.
+
+## Topics
+
+### Getting Started
+
+- <doc:Installation>
+- <doc:First-State-Machine>
+- <doc:SwiftUI-Basics>
+
+### Migration
+
+- <doc:MVVM-to-Oak>
+- <doc:Common-Patterns>
+
+### Core Concepts
+
+- <doc:Finite-State-Machines>
+- <doc:Transducers>
+- <doc:State-Modeling>
+- <doc:Effects>
+
+### SwiftUI Integration
+
+- <doc:TransducerView>
+- <doc:Environment-Injection>
+- <doc:Hierarchical-Architecture>
+
+### Examples
+
+- <doc:Counter-Example>
+- <doc:Data-Loading>
+- <doc:Form-Validation>
+- <doc:Navigation-Flow>
+
+### Testing
+
+- <doc:Testing-Transducers>
+- <doc:Testing-Effects>
+- <doc:Integration-Testing>
+
+### Advanced Usage
+
+- <doc:Performance>
+- <doc:Composition>
+- <doc:Debugging>

--- a/Sources/Oak/Documentation.docc/SwiftUI-Basics.md
+++ b/Sources/Oak/Documentation.docc/SwiftUI-Basics.md
@@ -1,0 +1,173 @@
+# SwiftUI Integration Basics
+
+Connect your state machines to SwiftUI views using TransducerView for reactive, lifecycle-aware state management.
+
+## TransducerView Fundamentals
+
+`TransducerView` is Oak's primary SwiftUI integration component. It manages the transducer lifecycle, handles state updates, and provides event input capabilities.
+
+### Basic Integration
+
+Here's how to connect the counter from the previous section to a SwiftUI view:
+
+```swift
+import SwiftUI
+import Oak
+
+struct CounterView: View {
+    @State private var counterState = Counter.initialState
+    
+    var body: some View {
+        TransducerView(
+            of: Counter.self,
+            initialState: $counterState
+        ) { state, input in
+            VStack(spacing: 20) {
+                Text("Count: \(state.count)")
+                    .font(.title)
+                
+                HStack(spacing: 15) {
+                    Button("Increment") {
+                        try? input.send(.increment)
+                        // Simulate async completion
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                            try? input.send(.incrementComplete)
+                        }
+                    }
+                    .disabled(!state.canIncrement)
+                    
+                    Button("Decrement") {
+                        try? input.send(.decrement)
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                            try? input.send(.decrementComplete)
+                        }
+                    }
+                    .disabled(!state.canDecrement)
+                }
+            }
+            .padding()
+        }
+    }
+}
+
+extension Counter.State {
+    var canIncrement: Bool {
+        if case .idle = self { return true }
+        return false
+    }
+    
+    var canDecrement: Bool {
+        if case .idle = self { return true }
+        return false
+    }
+}
+```
+
+## How TransducerView Works
+
+### State Binding
+
+TransducerView uses a `@State` binding from the parent view. This allows:
+
+- **Parent Observation**: The parent view can react to state changes
+- **SwiftUI Integration**: Automatic view updates when state changes
+- **Lifecycle Management**: State persists across view updates
+
+### Event Input
+
+The `input` parameter in the view closure provides a way to send events to the transducer:
+
+```swift
+try? input.send(.increment)
+```
+
+Events are processed asynchronously and may trigger state transitions.
+
+### Automatic Lifecycle
+
+TransducerView handles:
+
+- **Startup**: Automatically starts the transducer when the view appears
+- **Updates**: Triggers view redraws when state changes
+- **Cleanup**: Cancels ongoing effects when the view disappears
+
+## State-Driven UI
+
+Oak encourages state-driven UI design where view appearance is determined entirely by current state:
+
+```swift
+VStack {
+    switch state {
+    case .idle(let count):
+        Text("Ready: \(count)")
+            .foregroundColor(.primary)
+        
+    case .incrementing(let count):
+        HStack {
+            ProgressView()
+                .scaleEffect(0.8)
+            Text("Adding... \(count)")
+        }
+        .foregroundColor(.blue)
+        
+    case .decrementing(let count):
+        HStack {
+            ProgressView()
+                .scaleEffect(0.8)
+            Text("Subtracting... \(count)")
+        }
+        .foregroundColor(.orange)
+    }
+}
+```
+
+This approach eliminates the need for separate loading flags or error states since they're encoded in the state machine.
+
+## Parent-Child Communication
+
+TransducerView supports output handling for communication with parent views:
+
+```swift
+struct ParentView: View {
+    @State private var counterState = Counter.initialState
+    @State private var message = "Waiting for updates..."
+    
+    var body: some View {
+        VStack {
+            Text(message)
+                .padding()
+            
+            TransducerView(
+                of: Counter.self,
+                initialState: $counterState
+            ) { state, input in
+                // Counter UI here
+                CounterContent(state: state, input: input)
+            } output: { count in
+                message = "Counter updated to: \(count)"
+            }
+        }
+    }
+}
+```
+
+## Error Handling
+
+TransducerView provides error handling for event sending:
+
+```swift
+Button("Increment") {
+    do {
+        try input.send(.increment)
+    } catch {
+        // Handle event sending errors
+        print("Failed to send event: \(error)")
+    }
+}
+```
+
+In practice, event sending rarely fails unless the transducer is in a terminal state or has been cancelled.
+
+## What's Next
+
+This covers basic SwiftUI integration with simple transducers. For handling asynchronous operations like network requests, see <doc:Effects>. For more complex UI patterns, see <doc:Hierarchical-Architecture>.

--- a/Sources/Oak/Documentation.docc/Testing-Transducers.md
+++ b/Sources/Oak/Documentation.docc/Testing-Transducers.md
@@ -1,0 +1,434 @@
+# Testing Transducers and Effects
+
+Comprehensive testing strategies for Oak state machines, from pure state logic to complex effect interactions.
+
+## Testing Pure State Transitions
+
+Transducer update functions are pure, making them straightforward to test:
+
+```swift
+import Testing
+import Oak
+
+@Suite("Counter State Transitions")
+struct CounterTests {
+    
+    @Test("Initial state is idle with zero count")
+    func testInitialState() {
+        let state = Counter.initialState
+        #expect(state.count == 0)
+    }
+    
+    @Test("Increment increases count")
+    func testIncrement() {
+        var state = Counter.State.idle(count: 5)
+        let output = Counter.update(&state, event: .increment)
+        
+        #expect(output == 6)
+        if case .idle(let count) = state {
+            #expect(count == 6)
+        } else {
+            Issue.record("Expected idle state")
+        }
+    }
+    
+    @Test("Decrement respects minimum of zero")
+    func testDecrementMinimum() {
+        var state = Counter.State.idle(count: 0)
+        let output = Counter.update(&state, event: .decrement)
+        
+        #expect(output == 0)
+        if case .idle(let count) = state {
+            #expect(count == 0)
+        } else {
+            Issue.record("Expected idle state")
+        }
+    }
+}
+```
+
+## Testing State Machine Properties
+
+### Exhaustive Transition Testing
+
+Test all valid state and event combinations:
+
+```swift
+@Suite("Login Flow Transitions")
+struct LoginFlowTests {
+    
+    @Test("All valid transitions", arguments: [
+        (.start, .begin, .enteringCredentials),
+        (.enteringCredentials, .submit, .authenticating),
+        (.authenticating, .success, .authenticated),
+        (.authenticating, .failure, .failed),
+        (.failed, .retry, .enteringCredentials)
+    ])
+    func testValidTransitions(
+        initial: LoginFlow.State,
+        event: LoginFlow.Event,
+        expected: LoginFlow.State
+    ) {
+        var state = initial
+        _ = LoginFlow.update(&state, event: event)
+        #expect(state == expected)
+    }
+    
+    @Test("Invalid transitions are ignored")
+    func testInvalidTransitions() {
+        var state = LoginFlow.State.authenticated
+        let originalState = state
+        
+        // These events should not change state when authenticated
+        _ = LoginFlow.update(&state, event: .begin)
+        #expect(state == originalState)
+        
+        _ = LoginFlow.update(&state, event: .submit)
+        #expect(state == originalState)
+    }
+}
+```
+
+### Terminal State Testing
+
+Verify terminal state behavior:
+
+```swift
+@Test("Terminal states cannot transition")
+func testTerminalStates() {
+    let terminalStates: [ProcessFlow.State] = [
+        .completed(.success),
+        .completed(.failure),
+        .cancelled
+    ]
+    
+    for var terminalState in terminalStates {
+        #expect(terminalState.isTerminal)
+        
+        let originalState = terminalState
+        _ = ProcessFlow.update(&terminalState, event: .retry)
+        #expect(terminalState == originalState, "Terminal state should not change")
+    }
+}
+```
+
+## Testing Effects
+
+### Mock Environments
+
+Create predictable test environments:
+
+```swift
+extension DataLoader.Env {
+    static func test(
+        shouldSucceed: Bool = true,
+        delay: TimeInterval = 0,
+        data: [DataItem] = []
+    ) -> Self {
+        Self(
+            dataService: {
+                if delay > 0 {
+                    try await Task.sleep(for: .seconds(delay))
+                }
+                if shouldSucceed {
+                    return data
+                } else {
+                    throw TestError.networkError
+                }
+            },
+            logger: { _ in } // No-op logger for tests
+        )
+    }
+}
+
+enum TestError: Error {
+    case networkError
+    case timeout
+}
+```
+
+### Effect Execution Testing
+
+Test effect behavior in isolation:
+
+```swift
+@Suite("Data Loading Effects")
+struct DataLoaderEffectTests {
+    
+    @Test("Load data effect sends success event")
+    func testLoadDataSuccess() async throws {
+        let expectedData = [DataItem(id: 1, name: "Test")]
+        let env = DataLoader.Env.test(data: expectedData)
+        
+        var receivedEvents: [DataLoader.Event] = []
+        let input = MockInput { event in
+            receivedEvents.append(event)
+        }
+        
+        let effect = DataLoader.loadDataEffect()
+        try await effect.run(env: env, input: input)
+        
+        #expect(receivedEvents.count == 1)
+        if case .dataLoaded(let items) = receivedEvents.first {
+            #expect(items == expectedData)
+        } else {
+            Issue.record("Expected dataLoaded event")
+        }
+    }
+    
+    @Test("Load data effect sends failure event on error")
+    func testLoadDataFailure() async throws {
+        let env = DataLoader.Env.test(shouldSucceed: false)
+        
+        var receivedEvents: [DataLoader.Event] = []
+        let input = MockInput { event in
+            receivedEvents.append(event)
+        }
+        
+        let effect = DataLoader.loadDataEffect()
+        try await effect.run(env: env, input: input)
+        
+        #expect(receivedEvents.count == 1)
+        if case .loadFailed(let error) = receivedEvents.first {
+            #expect(error is TestError)
+        } else {
+            Issue.record("Expected loadFailed event")
+        }
+    }
+}
+```
+
+### Mock Input Helper
+
+Create a reusable mock input for testing:
+
+```swift
+class MockInput<Event>: @unchecked Sendable {
+    private let eventHandler: @Sendable (Event) throws -> Void
+    private let lock = NSLock()
+    private var _events: [Event] = []
+    
+    init(eventHandler: @escaping @Sendable (Event) throws -> Void) {
+        self.eventHandler = eventHandler
+    }
+    
+    var events: [Event] {
+        lock.withLock { _events }
+    }
+    
+    func send(_ event: Event) throws {
+        lock.withLock { _events.append(event) }
+        try eventHandler(event)
+    }
+}
+```
+
+## Integration Testing
+
+### TransducerView Testing
+
+Test SwiftUI integration using view testing:
+
+```swift
+@Test("TransducerView responds to state changes")
+func testTransducerViewIntegration() async throws {
+    let expectation = XCTestExpectation(description: "State change")
+    
+    struct TestView: View {
+        @State private var state = Counter.initialState
+        let onStateChange: (Counter.State) -> Void
+        
+        var body: some View {
+            TransducerView(
+                of: Counter.self,
+                initialState: $state
+            ) { state, input in
+                VStack {
+                    Text("Count: \(state.count)")
+                    Button("Increment") {
+                        try? input.send(.increment)
+                    }
+                }
+                .onChange(of: state) { newState in
+                    onStateChange(newState)
+                }
+            }
+        }
+    }
+    
+    let view = TestView { state in
+        if state.count > 0 {
+            expectation.fulfill()
+        }
+    }
+    
+    // Simulate button tap
+    // Implementation depends on your testing framework
+    
+    await fulfillment(of: [expectation], timeout: 1.0)
+}
+```
+
+### Full Workflow Testing
+
+Test complete user workflows:
+
+```swift
+@Test("Complete login workflow")
+func testLoginWorkflow() async throws {
+    let env = LoginTransducer.Env.test(shouldSucceed: true)
+    var state = LoginTransducer.initialState
+    
+    // Start login
+    var effect = LoginTransducer.update(&state, event: .startLogin)
+    #expect(state == .enteringCredentials)
+    #expect(effect == nil)
+    
+    // Enter credentials
+    effect = LoginTransducer.update(&state, event: .updateEmail("test@example.com"))
+    #expect(effect == nil)
+    
+    effect = LoginTransducer.update(&state, event: .updatePassword("password"))
+    #expect(effect == nil)
+    
+    // Submit credentials
+    effect = LoginTransducer.update(&state, event: .submit)
+    #expect(state == .authenticating)
+    #expect(effect != nil)
+    
+    // Simulate successful authentication
+    let mockInput = MockInput<LoginTransducer.Event> { _ in }
+    try await effect!.run(env: env, input: mockInput)
+    
+    // Verify success event was sent
+    if case .authenticationSucceeded = mockInput.events.first {
+        // Process success event
+        effect = LoginTransducer.update(&state, event: .authenticationSucceeded(testUser))
+        #expect(state == .authenticated(testUser))
+    } else {
+        Issue.record("Expected authentication success event")
+    }
+}
+```
+
+## Property-Based Testing
+
+Test state machine invariants:
+
+```swift
+@Test("State machine invariants")
+func testStateMachineInvariants() {
+    let allStates: [MyTransducer.State] = [
+        .idle, .loading, .loaded([]), .error(TestError.networkError)
+    ]
+    
+    let allEvents: [MyTransducer.Event] = [
+        .load, .reload, .cancel, .dataReceived([]), .loadFailed(TestError.networkError)
+    ]
+    
+    for initialState in allStates {
+        for event in allEvents {
+            var state = initialState
+            let effect = MyTransducer.update(&state, event: event)
+            
+            // Invariant: update function always returns a valid state
+            #expect(isValidState(state))
+            
+            // Invariant: terminal states don't transition
+            if initialState.isTerminal {
+                #expect(state == initialState, "Terminal state should not change")
+                #expect(effect == nil, "Terminal state should not produce effects")
+            }
+        }
+    }
+}
+
+func isValidState(_ state: MyTransducer.State) -> Bool {
+    switch state {
+    case .idle, .loading, .loaded, .error:
+        return true
+    }
+}
+```
+
+## Performance Testing
+
+Test state machine performance:
+
+```swift
+@Test("State transition performance")
+func testStateTransitionPerformance() {
+    let options = Test.TimeLimit(.minutes(1))
+    
+    measure(options: options) {
+        var state = Counter.State.idle(count: 0)
+        
+        for _ in 0..<10000 {
+            _ = Counter.update(&state, event: .increment)
+        }
+        
+        if case .idle(let count) = state {
+            #expect(count == 10000)
+        }
+    }
+}
+```
+
+## Test Organization
+
+### Test Structure
+
+Organize tests by functionality:
+
+```
+Tests/
+├── TransducerTests/
+│   ├── CounterTests.swift
+│   ├── LoginFlowTests.swift
+│   └── DataLoaderTests.swift
+├── EffectTests/
+│   ├── NetworkEffectTests.swift
+│   └── TimerEffectTests.swift
+├── IntegrationTests/
+│   ├── TransducerViewTests.swift
+│   └── WorkflowTests.swift
+└── Utilities/
+    ├── MockInput.swift
+    ├── TestEnvironments.swift
+    └── TestHelpers.swift
+```
+
+### Test Utilities
+
+Create reusable test utilities:
+
+```swift
+// Test data generators
+enum TestData {
+    static func randomUsers(count: Int) -> [User] {
+        (0..<count).map { User(id: $0, name: "User \($0)") }
+    }
+    
+    static func randomError() -> Error {
+        [TestError.networkError, TestError.timeout].randomElement()!
+    }
+}
+
+// State machine test helpers
+extension StateMachine {
+    static func testTransition(
+        from initialState: State,
+        event: Event,
+        expectedState: State,
+        expectedEffect: Effect? = nil
+    ) {
+        var state = initialState
+        let effect = update(&state, event: event)
+        
+        #expect(state == expectedState)
+        #expect(type(of: effect) == type(of: expectedEffect))
+    }
+}
+```
+
+Testing Oak state machines follows standard Swift testing practices but benefits from the predictable, pure nature of state transitions. Focus on testing state logic separately from effects, use mock environments for predictable effect testing, and verify complete workflows to ensure your application behaves correctly under all conditions.

--- a/Sources/Oak/Documentation.docc/TransducerView.md
+++ b/Sources/Oak/Documentation.docc/TransducerView.md
@@ -1,0 +1,464 @@
+# TransducerView: Complete Reference
+
+TransducerView is Oak's primary SwiftUI integration component, providing lifecycle-aware state machine management with reactive updates and environment injection.
+
+## Basic Usage
+
+TransducerView manages a transducer's complete lifecycle within SwiftUI's view system:
+
+```swift
+struct CounterView: View {
+    @State private var counterState = Counter.initialState
+    
+    var body: some View {
+        TransducerView(
+            of: Counter.self,
+            initialState: $counterState
+        ) { state, input in
+            VStack {
+                Text("Count: \(state.count)")
+                
+                Button("Increment") {
+                    try? input.send(.increment)
+                }
+            }
+        }
+    }
+}
+```
+
+## Lifecycle Management
+
+### Automatic Startup
+
+TransducerView automatically starts the transducer when the view appears:
+
+- Creates the transducer actor
+- Begins processing events
+- Starts any initial effects
+
+### State Synchronization
+
+Changes to the transducer's internal state automatically update the SwiftUI view:
+
+```swift
+// State changes trigger view updates
+TransducerView(...) { state, input in
+    switch state {
+    case .idle:
+        IdleView()
+    case .loading:
+        ProgressView() // Automatically shown when state changes
+    case .loaded(let data):
+        DataView(data: data)
+    }
+}
+```
+
+### Cleanup
+
+When the view disappears, TransducerView:
+
+- Cancels all running effects
+- Stops the transducer actor
+- Releases resources
+
+## Environment Injection
+
+### Basic Environment Setup
+
+For EffectTransducers, provide environment through SwiftUI's environment system:
+
+```swift
+// Define environment entry
+extension EnvironmentValues {
+    @Entry var dataLoaderEnv: DataLoader.Env = .production
+}
+
+// Provide environment in parent view
+struct ContentView: View {
+    var body: some View {
+        DataView()
+            .environment(\.dataLoaderEnv, .production)
+    }
+}
+
+// Use environment in TransducerView
+struct DataView: View {
+    @State private var state = DataLoader.initialState
+    @Environment(\.dataLoaderEnv) var env
+    
+    var body: some View {
+        TransducerView(
+            of: DataLoader.self,
+            initialState: $state,
+            env: env
+        ) { state, input in
+            // View content
+        }
+    }
+}
+```
+
+### Environment Variants
+
+Create different environments for different contexts:
+
+```swift
+extension DataLoader.Env {
+    static var production: Self {
+        Self(
+            dataService: RealDataService.shared.fetchData,
+            logger: OSLog.default.log
+        )
+    }
+    
+    static var preview: Self {
+        Self(
+            dataService: { PreviewData.sampleItems },
+            logger: { _ in }
+        )
+    }
+    
+    static var test: Self {
+        Self(
+            dataService: { MockData.items },
+            logger: { print($0) }
+        )
+    }
+}
+```
+
+## Output Handling
+
+### Basic Output Handling
+
+Handle transducer outputs for parent communication:
+
+```swift
+struct ParentView: View {
+    @State private var childState = ChildTransducer.initialState
+    @State private var parentMessage = ""
+    
+    var body: some View {
+        VStack {
+            Text(parentMessage)
+            
+            TransducerView(
+                of: ChildTransducer.self,
+                initialState: $childState
+            ) { state, input in
+                ChildContent(state: state, input: input)
+            } output: { result in
+                parentMessage = "Child completed with: \(result)"
+            }
+        }
+    }
+}
+```
+
+### Complex Output Patterns
+
+Use outputs to coordinate between multiple transducers:
+
+```swift
+struct CoordinatedView: View {
+    @State private var authState = AuthTransducer.initialState
+    @State private var dataState = DataTransducer.initialState
+    @Environment(\.authEnv) var authEnv
+    @Environment(\.dataEnv) var dataEnv
+    
+    var body: some View {
+        VStack {
+            TransducerView(
+                of: AuthTransducer.self,
+                initialState: $authState,
+                env: authEnv
+            ) { state, input in
+                AuthView(state: state, input: input)
+            } output: { authResult in
+                // Forward auth result to data transducer
+                if case .authenticated(let token) = authResult {
+                    // Update data environment with auth token
+                    // Or send event to data transducer
+                }
+            }
+            
+            TransducerView(
+                of: DataTransducer.self,
+                initialState: $dataState,
+                env: dataEnv
+            ) { state, input in
+                DataView(state: state, input: input)
+            }
+        }
+    }
+}
+```
+
+## Advanced Integration Patterns
+
+### State-Driven Navigation
+
+Use transducer state to drive navigation decisions:
+
+```swift
+struct NavigationCoordinator: View {
+    @State private var coordinatorState = NavigationTransducer.initialState
+    
+    var body: some View {
+        TransducerView(
+            of: NavigationTransducer.self,
+            initialState: $coordinatorState
+        ) { state, input in
+            NavigationStack {
+                switch state {
+                case .home:
+                    HomeView()
+                    
+                case .profile(let user):
+                    ProfileView(user: user)
+                    
+                case .settings:
+                    SettingsView()
+                    
+                case .modal(let content):
+                    HomeView()
+                        .sheet(isPresented: .constant(true)) {
+                            ModalView(content: content)
+                        }
+                }
+            }
+        }
+    }
+}
+```
+
+### Modal Management
+
+Handle sheet and alert presentation through state:
+
+```swift
+enum AppState {
+    case idle
+    case showingSheet(SheetContent)
+    case showingAlert(AlertContent)
+}
+
+struct AppView: View {
+    @State private var appState = AppTransducer.initialState
+    
+    var body: some View {
+        TransducerView(
+            of: AppTransducer.self,
+            initialState: $appState
+        ) { state, input in
+            ContentView()
+                .sheet(
+                    isPresented: Binding(
+                        get: { 
+                            if case .showingSheet = state { return true }
+                            return false
+                        },
+                        set: { if !$0 { try? input.send(.dismissSheet) } }
+                    )
+                ) {
+                    if case .showingSheet(let content) = state {
+                        SheetView(content: content)
+                    }
+                }
+                .alert(
+                    "Alert",
+                    isPresented: Binding(
+                        get: {
+                            if case .showingAlert = state { return true }
+                            return false
+                        },
+                        set: { if !$0 { try? input.send(.dismissAlert) } }
+                    )
+                ) {
+                    Button("OK") {
+                        try? input.send(.dismissAlert)
+                    }
+                }
+        }
+    }
+}
+```
+
+### Form Integration
+
+Integrate with SwiftUI forms and validation:
+
+```swift
+struct FormView: View {
+    @State private var formState = FormTransducer.initialState
+    
+    var body: some View {
+        TransducerView(
+            of: FormTransducer.self,
+            initialState: $formState
+        ) { state, input in
+            Form {
+                Section("User Information") {
+                    TextField("Name", text: Binding(
+                        get: { state.name },
+                        set: { try? input.send(.updateName($0)) }
+                    ))
+                    
+                    TextField("Email", text: Binding(
+                        get: { state.email },
+                        set: { try? input.send(.updateEmail($0)) }
+                    ))
+                }
+                
+                Section("Validation") {
+                    ForEach(state.validationErrors, id: \.self) { error in
+                        Text(error.localizedDescription)
+                            .foregroundColor(.red)
+                    }
+                }
+                
+                Section {
+                    Button("Submit") {
+                        try? input.send(.submit)
+                    }
+                    .disabled(!state.isValid)
+                }
+            }
+        }
+    }
+}
+```
+
+## Performance Considerations
+
+### State Binding Optimization
+
+TransducerView uses SwiftUI's built-in diffing for efficient updates:
+
+```swift
+// Good: State changes trigger minimal view updates
+enum State {
+    case loading(progress: Double)
+    case loaded(itemCount: Int)  // Only count changes trigger updates
+}
+
+// Avoid: Large state copying
+enum State {
+    case loaded([HeavyDataItem])  // Full array comparison on every update
+}
+```
+
+### View Composition
+
+Break complex views into smaller components:
+
+```swift
+struct ComplexView: View {
+    @State private var state = ComplexTransducer.initialState
+    
+    var body: some View {
+        TransducerView(
+            of: ComplexTransducer.self,
+            initialState: $state
+        ) { state, input in
+            VStack {
+                HeaderComponent(state: state.header, input: input)
+                ContentComponent(state: state.content, input: input)
+                FooterComponent(state: state.footer, input: input)
+            }
+        }
+    }
+}
+```
+
+## Testing TransducerView
+
+### Preview Testing
+
+Use preview environments for SwiftUI previews:
+
+```swift
+struct DataView_Previews: PreviewProvider {
+    static var previews: some View {
+        DataView()
+            .environment(\.dataLoaderEnv, .preview)
+    }
+}
+```
+
+### Unit Testing
+
+Test view integration using SwiftUI testing:
+
+```swift
+@Test
+func testDataViewLoading() async throws {
+    let view = DataView()
+        .environment(\.dataLoaderEnv, .test)
+    
+    // Test initial state
+    #expect(view.state == .idle)
+    
+    // Trigger loading
+    try view.input.send(.load)
+    
+    // Verify loading state
+    #expect(view.state == .loading)
+}
+```
+
+## Common Patterns
+
+### Parent as Coordinator
+
+Use parent views to coordinate multiple child transducers:
+
+```swift
+struct CoordinatorView: View {
+    @State private var authState = AuthTransducer.initialState
+    @State private var mainState = MainTransducer.initialState
+    
+    var body: some View {
+        if case .authenticated = authState {
+            MainAppView(state: $mainState)
+        } else {
+            AuthView(state: $authState) { authResult in
+                // Handle authentication success
+                if case .success = authResult {
+                    // Initialize main app state
+                }
+            }
+        }
+    }
+}
+```
+
+### Conditional Rendering
+
+Use state to conditionally render view hierarchies:
+
+```swift
+TransducerView(...) { state, input in
+    switch state {
+    case .loading:
+        LoadingView()
+        
+    case .empty:
+        EmptyStateView {
+            try? input.send(.refresh)
+        }
+        
+    case .error(let error):
+        ErrorView(error: error) {
+            try? input.send(.retry)
+        }
+        
+    case .loaded(let data):
+        DataListView(data: data)
+    }
+}
+```
+
+TransducerView provides a powerful, declarative way to integrate Oak's state machines with SwiftUI while maintaining clean separation of concerns and predictable behavior.

--- a/Sources/Oak/Documentation.docc/Transducers.md
+++ b/Sources/Oak/Documentation.docc/Transducers.md
@@ -1,0 +1,353 @@
+# Transducers and EffectTransducers
+
+Oak provides two main protocols for implementing finite state machines: `Transducer` for pure state transitions and `EffectTransducer` for state machines that need to perform side effects.
+
+## Transducer: Pure State Machines
+
+The `Transducer` protocol is designed for state machines that only perform pure computations without side effects.
+
+### Basic Structure
+
+```swift
+enum SimpleCounter: Transducer {
+    enum State: NonTerminal {
+        case idle(count: Int)
+    }
+    
+    enum Event {
+        case increment
+        case decrement
+        case reset
+    }
+    
+    typealias Output = Int
+    
+    static var initialState: State {
+        .idle(count: 0)
+    }
+    
+    static func update(_ state: inout State, event: Event) -> Output {
+        switch (state, event) {
+        case (.idle(let count), .increment):
+            let newCount = count + 1
+            state = .idle(count: newCount)
+            return newCount
+            
+        case (.idle(let count), .decrement):
+            let newCount = max(0, count - 1)
+            state = .idle(count: newCount)
+            return newCount
+            
+        case (.idle, .reset):
+            state = .idle(count: 0)
+            return 0
+        }
+    }
+    
+    static func initialOutput(initialState: State) -> Output? {
+        if case .idle(let count) = initialState {
+            return count
+        }
+        return nil
+    }
+}
+```
+
+### Key Characteristics
+
+**Pure Functions**: The `update` function must be deterministic and free of side effects. No network calls, file operations, or other external interactions.
+
+**Direct Output**: Returns output values directly from the `update` function.
+
+**No Environment**: Simple transducers don't require external dependencies.
+
+**Immediate Execution**: All state transitions happen synchronously.
+
+## The Update Function: Theoretical Foundation
+
+Oak's `update` function is a powerful abstraction that combines the classical finite state machine concepts of transition and output functions into a single, unified interface.
+
+### Classical FSM Theory Background
+
+In traditional finite state machine theory, automata are classified based on how they generate output:
+
+**Moore Automata**: Output depends only on the current state
+- Output function: `λ(state) → output`
+- Outputs are stable and only change when state changes
+- No timing glitches since output is purely state-dependent
+
+**Mealy Automata**: Output depends on both current state and input event
+- Output function: `λ(state, event) → output`
+- Outputs can change immediately when inputs change
+- More expressive but can have timing glitches in hardware implementations
+
+### Oak's Unified Approach
+
+Oak's `update` function elegantly combines both the transition function and output function:
+
+```swift
+// Classical FSM would have separate functions:
+// δ(state, event) → new_state     (transition function)
+// λ(state, event) → output        (output function - Mealy)
+// λ(state) → output               (output function - Moore)
+
+// Oak combines both into update:
+static func update(_ state: inout State, event: Event) -> Output {
+    // Transition: modify state in-place
+    state = newState
+    
+    // Output: return based on state and/or event (flexible Mealy/Moore)
+    return computedOutput
+}
+```
+
+This unified approach provides several advantages:
+
+**Flexibility**: Choose Moore-style (state-only), Mealy-style (state+event), or mixed approaches per transition:
+
+```swift
+static func update(_ state: inout State, event: Event) -> String {
+    switch (state, event) {
+    case (.idle, .start):
+        state = .running
+        return "Started"  // Mealy-style: output depends on event
+        
+    case (.running, .tick):
+        state = .running
+        return state.description  // Moore-style: output depends only on state
+        
+    case (.running, .stop):
+        state = .stopped
+        return "Transition from \(state) via \(event)"  // Mixed: uses both
+    }
+}
+```
+
+**Atomicity**: State transition and output generation happen atomically, preventing inconsistent intermediate states.
+
+**Simplicity**: Single function interface reduces cognitive load compared to managing separate transition and output functions.
+
+**Software Advantages**: Since Oak runs in software rather than hardware, timing glitches (a concern with Mealy machines in hardware) are not an issue, allowing full flexibility in output generation strategies.
+
+### Moore vs Mealy: Theory vs Practice
+
+While understanding the theoretical distinctions is valuable for context, **in practice, you rarely need to consciously choose between Moore and Mealy approaches**. Oak's unified `update` function is designed to be so intuitive that you naturally implement the right behavior for each situation.
+
+The theoretical framework provides the robust foundation, but the interface is forgiving - you simply implement what feels natural:
+
+```swift
+static func update(_ state: inout State, event: Event) -> String {
+    switch (state, event) {
+    case (.idle, .start):
+        state = .running
+        return "Started"  // Naturally event-driven response
+        
+    case (.running, .tick):
+        state = .running  
+        return "Still running"  // Naturally state-based status
+        
+    case (.running, .stop):
+        state = .stopped
+        return "Stopped"  // Mix of both - and that's perfectly fine
+    }
+}
+```
+
+**The beauty of Oak's design**: You can't really "do it wrong" - the unified approach naturally guides you toward the appropriate output strategy for each transition. Whether your output ends up being Moore-style, Mealy-style, or mixed doesn't matter; what matters is that it correctly represents your application's logic.
+
+The theoretical knowledge serves as background understanding of why the design works so well, rather than as a decision-making framework you need to actively apply.
+
+### Initial Output Function
+
+Oak also provides `initialOutput(initialState:)` for Moore-style automata, allowing states to have outputs even before any events are processed:
+
+```swift
+static func initialOutput(initialState: State) -> Output? {
+    switch initialState {
+    case .idle(let count):
+        return count  // State has meaningful output from the start
+    case .uninitialized:
+        return nil   // No initial output until first transition
+    }
+}
+```
+
+This theoretical foundation enables Oak to provide both the predictability of Moore machines and the expressiveness of Mealy machines, while the software environment eliminates the timing concerns that traditionally favor Moore machines in hardware implementations.
+
+## EffectTransducer: State Machines with Side Effects
+
+The `EffectTransducer` protocol handles state machines that need to perform asynchronous operations or interact with external systems. For comprehensive coverage of Effects, see <doc:Effects>.
+
+### Basic Structure
+
+```swift
+enum DataLoader: EffectTransducer {
+    enum State: NonTerminal {
+        case idle
+        case loading
+        case loaded([DataItem])
+        case error(Error)
+    }
+    
+    enum Event {
+        case load
+        case dataReceived([DataItem])
+        case loadFailed(Error)
+        case retry
+    }
+    
+    struct Env: Sendable {
+        var dataService: @Sendable () async throws -> [DataItem]
+        var logger: @Sendable (String) -> Void
+    }
+    
+    static var initialState: State {
+        .idle
+    }
+    
+    static func update(_ state: inout State, event: Event) -> Effect? {
+        switch (state, event) {
+        case (.idle, .load), (.error, .retry):
+            state = .loading
+            return loadDataEffect()
+            
+        case (.loading, .dataReceived(let items)):
+            state = .loaded(items)
+            return logEffect("Loaded \(items.count) items")
+            
+        case (.loading, .loadFailed(let error)):
+            state = .error(error)
+            return logEffect("Load failed: \(error)")
+            
+        default:
+            return nil
+        }
+    }
+    
+    // Effects are declarative descriptions of side effects
+    static func loadDataEffect() -> Effect {
+        Effect { env, input in
+            do {
+                let items = try await env.dataService()
+                try input.send(.dataReceived(items))
+            } catch {
+                try input.send(.loadFailed(error))
+            }
+        }
+    }
+    
+    static func logEffect(_ message: String) -> Effect {
+        Effect.action { env in
+            env.logger(message)
+        }
+    }
+}
+```
+
+### Key Characteristics
+
+**Effect Return**: The `update` function returns `Effect?` instead of output directly.
+
+**Environment Support**: Effects receive a typed environment containing dependencies.
+
+**Pure Update Function**: Effects are created in the pure `update` function but executed later by Oak's runtime.
+
+> For detailed information about Effect types, creation patterns, environment design, testing, and advanced usage, see <doc:Effects>.
+
+## Choosing Between Transducer and EffectTransducer
+
+### Use Transducer When:
+
+- Pure computation only (no side effects)
+- Simple state transformations
+- Immediate, synchronous operations
+- No external dependencies needed
+- Direct output generation
+
+**Examples**: Calculators, form validation, UI state management, data filtering.
+
+### Use EffectTransducer When:
+
+- Network requests or API calls  
+- File system operations
+- Database interactions
+- Timer operations
+- Logging or analytics
+- Creating objects or "things"
+- Any async operations
+- Any side effects (whether obviously external or internal)
+
+**Examples**: Data loading, authentication flows, file uploads, real-time updates, object creation, timer management.
+
+## State Protocol Requirements
+
+### NonTerminal States
+
+For state machines that never reach a final state:
+
+```swift
+enum State: NonTerminal {
+    case idle
+    case active
+    case paused
+    // No terminal states
+}
+```
+
+### Terminable States
+
+For state machines with completion states:
+
+```swift
+enum State: Terminable {
+    case start
+    case processing
+    case completed
+    case cancelled
+    case failed(Error)
+    
+    var isTerminal: Bool {
+        switch self {
+        case .completed, .cancelled, .failed:
+            return true
+        case .start, .processing:
+            return false
+        }
+    }
+}
+```
+
+## Output Generation
+
+### Transducer Output
+
+Simple transducers generate output directly:
+
+```swift
+static func update(_ state: inout State, event: Event) -> String {
+    switch (state, event) {
+    case (.idle, .greet):
+        state = .greeted
+        return "Hello, World!"
+    }
+}
+```
+
+### EffectTransducer Output
+
+Effect transducers can generate both effects and output:
+
+```swift
+static func update(_ state: inout State, event: Event) -> (Effect?, String) {
+    switch (state, event) {
+    case (.idle, .greet):
+        state = .greeted
+        let effect = logEffect("User greeted")
+        return (effect, "Hello, World!")
+    }
+}
+```
+
+The choice between `Transducer` and `EffectTransducer` depends on whether your state machine needs to execute any async throwing functions or perform any side effects. Both action effects and operation effects execute side effects - whether obviously external (POST requests, file operations) or less obviously so (creating timers, objects, or logging). Start with `Transducer` for pure state transitions and upgrade to `EffectTransducer` when any form of side effect becomes necessary.
+
+> For comprehensive coverage of Effects including environment design, error handling patterns, performance considerations, and testing strategies, see <doc:Effects>.

--- a/Sources/Oak/SwiftUI/TransducerView.swift
+++ b/Sources/Oak/SwiftUI/TransducerView.swift
@@ -170,7 +170,7 @@ private struct IfLet<T, Content: View>: View {
         if let value {
             content(value)
         } else {
-            EmptyView()
+            Color.clear
         }
     }
 }


### PR DESCRIPTION
The `IfLet` view returned an `EmptyView` in the `else` case, which caused
a task modifier not to be called. This issue broke the TransducerView
in cases where the proxy was not provided, and a default proxy has been
created by the TransducerView.
    
This commit changes the `else` path such that it returns "poper" view,
aka a `Color.Clear` which fixed the issue.