### PR TITLE
Fix conformances in Effect Initialiser

### DIFF
--- a/Sources/Oak/FSM/Effect.swift
+++ b/Sources/Oak/FSM/Effect.swift
@@ -332,7 +332,7 @@ extension Effect {
             Env,
             Input
         ) async throws -> Void
-    ) where Env: Sendable {
+    ) where Env: Sendable, Input: Sendable {
         self.f = { env, input, context, systemActor in
             let id = id == nil ? context.id() : ID(id!)
             let uid = context.uid()
@@ -461,7 +461,7 @@ extension Effect {
         after duration: C.Instant.Duration,
         tolerance: C.Instant.Duration? = nil,
         clock: C = ContinuousClock(),
-    ) {
+    ) where Env: Sendable, Input: Sendable {
         self.f = { env, input, context, systemActor in
             let id = id == nil ? context.id() : ID(id!)
             let uid = context.uid()

--- a/Sources/Oak/Oak.code-workspace
+++ b/Sources/Oak/Oak.code-workspace
@@ -1,0 +1,17 @@
+{
+	"folders": [
+		{
+			"path": "../.."
+		},
+		{
+			"path": "../../../../../../Documents/Bewerbungen/horaios"
+		},
+		{
+			"path": "../../../../../../Documents/Bewerbungen/Jobgether"
+		},
+		{
+			"path": "../../../../../../Documents/Bewerbungen/Cover Letter Examples"
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
• Add Sendable constraints to operation initializers that accept @isolated(any) closures 
• Ensure Env and Input are Sendable when passed across potentially different actor contexts 
• Keep isolated​Operation variants unchanged (they execute on the system actor and don’t require Sendable) 
• Aligns with Swift 6.3’s stricter cross-actor “sending” checks and isolation rules 
• No behavior changes beyond satisfying concurrency safety; Context remains system-actor–isolated